### PR TITLE
feat: quest generation and scoring skeleton (quest-service)

### DIFF
--- a/quest-service/app/models/quest.py
+++ b/quest-service/app/models/quest.py
@@ -1,0 +1,58 @@
+import uuid
+
+from sqlalchemy import Boolean, Float, Integer, String, Text
+from sqlalchemy.dialects.postgresql import ARRAY, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class Quest(Base):
+    """
+    One generated quest instance (fill-in-the-blank).
+
+    Built from a LanguageContent row at runtime:
+      - question_fi: Finnish sentence with the target word replaced by ....
+      - question_en: English sentence with the target word replaced by ....
+      - options: 4 Finnish words (1 correct + 3 wrong), already shuffled
+      - correct_answer: never sent to frontend before submission
+    """
+
+    __tablename__ = "quests"
+
+    content_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        nullable=False,
+        index=True,
+    )
+
+    question_fi: Mapped[str] = mapped_column(Text, nullable=False)
+    question_en: Mapped[str] = mapped_column(Text, nullable=False)
+
+    options: Mapped[list] = mapped_column(ARRAY(String), nullable=False)
+    correct_answer: Mapped[str] = mapped_column(String(256), nullable=False)
+    difficulty: Mapped[float] = mapped_column(Float, nullable=False)
+
+    def __repr__(self) -> str:
+        return f"<Quest correct='{self.correct_answer}' difficulty={self.difficulty}>"
+
+
+class QuestSubmission(Base):
+    """Records one player answer to one quest."""
+
+    __tablename__ = "quest_submissions"
+
+    quest_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        nullable=False,
+        index=True,
+    )
+
+    user_id: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    given_answer: Mapped[str] = mapped_column(String(256), nullable=False)
+    is_correct: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    xp_earned: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    pack_score: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+
+    def __repr__(self) -> str:
+        return f"<QuestSubmission user={self.user_id} correct={self.is_correct}>"

--- a/quest-service/app/routers/quests.py
+++ b/quest-service/app/routers/quests.py
@@ -1,0 +1,121 @@
+"""
+Quests router — SKELETON.
+
+Three endpoints:
+  POST /quests/generate           - pick a sentence, blank it, return the quest (no answer)
+  POST /quests/generate-internal  - same but includes correct_answer (service-to-service only)
+  POST /quests/submit             - score the player's answer, return result + pack info
+
+Called by:
+  - Node.js (for quests shown to the player — uses /generate and /submit)
+  - Challenge Service (8003) via HTTP (uses /generate-internal to build
+    the question queue for a boss fight, needs correct_answer for local scoring)
+
+TODO: implement all three stubs by wiring up quest_service functions.
+"""
+
+from fastapi import APIRouter, Depends, Header, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import get_settings
+from app.core.database import get_db
+from app.schemas.quest import (
+    QuestGenerateRequest,
+    QuestOut,
+    QuestSubmitRequest,
+    QuestResult,
+)
+
+router = APIRouter(prefix="/quests", tags=["quests"])
+settings = get_settings()
+
+
+def _check_secret(x_service_secret: str = Header(...)) -> None:
+    """Rejects requests without the correct service-to-service secret."""
+    if x_service_secret != settings.SERVICE_SECRET:
+        raise HTTPException(status_code=403, detail="Forbidden.")
+
+
+@router.post("/generate", response_model=QuestOut, status_code=201)
+async def generate(
+    body: QuestGenerateRequest,
+    db: AsyncSession = Depends(get_db),
+) -> QuestOut:
+    """
+    Generate a new fill-in-the-blank quest (no correct_answer in response).
+    Called by Node.js for quests shown directly to the player.
+
+    Optional filters:
+      - scenario_tag: only pull sentences tagged with this scenario
+      - difficulty_target: float 0.0–1.0, picks the nearest available difficulty
+
+    TODO:
+      1. Call quest_service.generate_quest(db, user_id, scenario_tag, difficulty_target)
+      2. Map the returned Quest ORM object to QuestOut (no correct_answer) and return
+      3. Raise HTTP 404 if quest_service raises ValueError (no content in DB)
+    """
+    raise HTTPException(status_code=501, detail="Not implemented yet.")
+
+
+@router.post(
+    "/generate-internal",
+    dependencies=[Depends(_check_secret)],
+    status_code=201,
+)
+async def generate_internal(
+    body: QuestGenerateRequest,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """
+    Internal endpoint — returns the full quest INCLUDING correct_answer.
+    Protected by x-service-secret, never reachable by frontend users.
+
+    Called by the Challenge Service (8003) when building the question queue
+    for a boss fight. The Challenge Service stores correct_answer locally
+    in ChallengeQuestion rows so it can score answers without calling back here.
+
+    Returns:
+      {
+        "id": "uuid",
+        "question_fi": "...",
+        "question_en": "...",
+        "options": ["a", "b", "c", "d"],
+        "correct_answer": "kahvia",
+        "difficulty": 0.45
+      }
+
+    TODO:
+      1. Call quest_service.generate_quest(db, user_id, scenario_tag, difficulty_target)
+      2. Return ALL fields including quest.correct_answer as a plain dict
+      3. Raise HTTP 404 if quest_service raises ValueError
+    """
+    raise HTTPException(status_code=501, detail="Not implemented yet.")
+
+
+@router.post("/submit", response_model=QuestResult)
+async def submit(
+    body: QuestSubmitRequest,
+    db: AsyncSession = Depends(get_db),
+) -> QuestResult:
+    """
+    Submit a player's answer and score it.
+    Called by Node.js after the player picks an answer in a normal quest.
+
+    Returns:
+      - correct_answer  the word we were looking for (now revealed)
+      - is_correct      whether the player got it right
+      - feedback        "Correct!" or "The answer was kahvia."
+      - xp_earned       XP to add to the user's total
+      - pack_score      quality score for the pack (0.0–1.0)
+      - pack_awarded    True if pack_score >= PACK_AWARD_THRESHOLD (0.50)
+
+    If pack_awarded is True, Node.js should immediately call
+    Card Service POST /cards/open-pack with the returned pack_score.
+
+    TODO:
+      1. Fetch Quest row by body.quest_id (404 if not found)
+      2. Call quest_service.score_answer(quest.correct_answer, body.given_answer)
+      3. Persist a QuestSubmission row
+      4. Build and return QuestResult
+    """
+    raise HTTPException(status_code=501, detail="Not implemented yet.")

--- a/quest-service/app/schemas/quest.py
+++ b/quest-service/app/schemas/quest.py
@@ -1,0 +1,43 @@
+import uuid
+
+from pydantic import BaseModel, Field
+
+
+class QuestGenerateRequest(BaseModel):
+    """Sent by Node.js to request a new quest."""
+    user_id: str
+    scenario_tag: str | None = None
+    difficulty_target: float | None = None
+
+
+class QuestOut(BaseModel):
+    """
+    Returned after generating a quest.
+    correct_answer is NOT included — never expose it before submission.
+    """
+    id: uuid.UUID
+    question_fi: str
+    question_en: str
+    options: list[str]
+    difficulty: float
+
+    model_config = {"from_attributes": True}
+
+
+class QuestSubmitRequest(BaseModel):
+    """Sent by Node.js when the player picks an answer."""
+    quest_id: uuid.UUID
+    user_id: str
+    given_answer: str
+
+
+class QuestResult(BaseModel):
+    """Returned after scoring the player's answer."""
+    quest_id: uuid.UUID
+    correct_answer: str
+    given_answer: str
+    is_correct: bool
+    feedback: str
+    xp_earned: int
+    pack_score: float = Field(ge=0.0, le=1.0)
+    pack_awarded: bool

--- a/quest-service/app/services/quest_service.py
+++ b/quest-service/app/services/quest_service.py
@@ -1,0 +1,111 @@
+"""
+Quest service — SKELETON.
+
+Business logic for generating and scoring quests.
+All functions are called by the quests router.
+
+TODO: implement each function below.
+The logic already exists in the original python-service — port it here,
+renaming Challenge → Quest and challenge → quest throughout.
+"""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.quest import Quest
+
+# Pack is awarded when pack_score is at or above this threshold
+PACK_AWARD_THRESHOLD = 0.50
+
+
+async def generate_quest(
+    db: AsyncSession,
+    user_id: str,
+    scenario_tag: str | None = None,
+    difficulty_target: float | None = None,
+) -> Quest:
+    """
+    Generate one fill-in-the-blank quest.
+
+    Steps:
+      1. Pick a LanguageContent row (see _pick_content below)
+      2. Blank out target_fi in sentence_fi and target_en in sentence_en
+      3. Pull 3 distractor target_fi values from other rows
+      4. Shuffle all 4 options
+      5. Persist the Quest row and return it
+
+    Raises ValueError if no content is found.
+
+    TODO: port from original challenge_service.generate_challenge, rename Challenge → Quest
+    """
+    raise NotImplementedError
+
+
+def score_answer(
+    correct_answer: str,
+    given_answer: str,
+) -> tuple[bool, str, int, float]:
+    """
+    Score a multiple choice answer.
+
+    Returns (is_correct, feedback, xp_earned, pack_score).
+
+    TODO: port from original challenge_service.score_answer
+    """
+    raise NotImplementedError
+
+
+# ── Private helpers ────────────────────────────────────────────────────────────
+
+async def _pick_content(
+    db: AsyncSession,
+    scenario_tag: str | None,
+    difficulty_target: float | None,
+):
+    """
+    Pick one active LanguageContent row.
+
+    If difficulty_target is given, fetch the 5 nearest rows and pick randomly.
+    If scenario_tag is given, filter by it.
+    Otherwise, pick a completely random active row.
+
+    TODO: port from original challenge_service._pick_content
+    """
+    raise NotImplementedError
+
+
+def _blank_sentence(content) -> tuple[str, str]:
+    """
+    Replace target_fi in sentence_fi with .... and target_en in sentence_en with ....
+
+    e.g.
+      sentence_fi: "Haluaisin kupillisen kahvia, kiitos."
+      target_fi:   "kahvia"
+      result:      "Haluaisin kupillisen ...., kiitos."
+
+    TODO: port from original challenge_service._blank_sentence
+    """
+    raise NotImplementedError
+
+
+async def _build_options(db: AsyncSession, content) -> list[str]:
+    """
+    Pull 3 distractor target_fi values from other rows, shuffle with correct answer.
+
+    If DB is too small to find 3 distractors, pad with hardcoded Finnish filler words.
+
+    TODO: port from original challenge_service._build_options
+    """
+    raise NotImplementedError
+
+
+def _compute_xp(is_correct: bool) -> int:
+    """Returns 10 XP for correct, 2 XP for trying."""
+    raise NotImplementedError
+
+
+def _compute_pack_score(is_correct: bool) -> float:
+    """
+    Correct answer → random float in [0.50, 1.00] (always awards a pack)
+    Wrong answer   → random float in [0.00, 0.40] (never awards a pack)
+    """
+    raise NotImplementedError


### PR DESCRIPTION
This is PR 3 of 5 for the Python microservice split.
Builds on top of PR 2 (microservice/content).

Adds the quest system to quest-service. A quest is a fill-in-the-blank Finnish
sentence where the player picks the correct word from 4 options.
Completing a quest awards card packs.

## How quests work

1. Node.js calls POST /quests/generate
2. quest-service picks a sentence, blanks the target word, builds 4 options
3. Frontend shows the question WITHOUT the correct answer
4. Player picks an answer, Node.js calls POST /quests/submit
5. quest-service scores it and returns result + pack info
6. If pack_awarded is True, Node.js calls card-service POST /cards/open-pack

## New endpoints

- `POST /quests/generate` — returns a quest without correct answer (for players)
- `POST /quests/generate-internal` — returns quest WITH correct answer (service-to-service only, protected by x-service-secret)
- `POST /quests/submit` — scores the player's answer

## New files

- `app/models/quest.py` — Quest and QuestSubmission models
- `app/schemas/quest.py` — QuestOut, QuestGenerateRequest, QuestSubmitRequest, QuestResult
- `app/routers/quests.py` — router skeleton with TODO comments
- `app/services/quest_service.py` — service skeleton with TODO comments

## TODO (for the assigned developer)

If you have no idea where to start from,

Implement all functions marked with `raise NotImplementedError` in:
- `app/services/quest_service.py`
- `app/routers/quests.py`

The logic is identical to the original `challenge_service.py` in the old monolith.
Just rename Challenge → Quest throughout.
'''
## Checklist
- [x] Feature is fully done and works
- [x] Difficult parts of code have relevant comments
- [x] Feature is tested
- [x] PR includes clear description for later documentation