### PR TITLE
feat: card pack opening and weighted rarity engine

### DIFF
--- a/card-service/app/routers/cards.py
+++ b/card-service/app/routers/cards.py
@@ -1,0 +1,53 @@
+"""
+Cards router — SKELETON.
+
+One endpoint:
+  POST /cards/open-pack  - roll a pack and return the cards
+
+Called by Node.js immediately after:
+  - A quest (challenge) submission where pack_awarded == True
+  - A battle victory (Quiz Service tells Node.js how many bonus packs to open)
+
+Node.js passes back the pack_score from the challenge submission result.
+The rarity engine uses it to weight rolls toward rarer cards.
+
+Node.js is responsible for persisting the returned cards in its own DB as
+part of the user's inventory. This service only generates and returns card data.
+
+TODO: implement open_card_pack() by wiring up rarity_engine.open_pack()
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.schemas.card import CardOut, PackOpenRequest, PackOpenResult
+
+router = APIRouter(prefix="/cards", tags=["cards"])
+
+
+@router.post("/open-pack", response_model=PackOpenResult)
+async def open_card_pack(
+    body: PackOpenRequest,
+    db: AsyncSession = Depends(get_db),
+) -> PackOpenResult:
+    """
+    Roll a pack of cards and return them.
+
+    pack_score (0.0–1.0) controls rarity distribution:
+      0.50–0.60  mostly Common and Uncommon
+      0.60–0.80  mix of all rarities
+      0.80–1.00  higher chance of Rare, Epic, Legendary
+
+    Cards are NOT persisted here. Node.js receives them and saves
+    them to the user's inventory in the Node.js DB.
+
+    TODO:
+      1. Call rarity_engine.open_pack(db, pack_score, scenario_tags)
+      2. Raise HTTP 404 if open_pack returns an empty list (DB not seeded)
+      3. Map each PackCard to a CardOut
+      4. Set legendary_pulled = True if any card.rarity == "Legendary"
+      5. Return PackOpenResult
+    """
+    # TODO: implement
+    raise HTTPException(status_code=501, detail="Not implemented yet.")

--- a/card-service/app/schemas/card.py
+++ b/card-service/app/schemas/card.py
@@ -1,0 +1,34 @@
+import uuid
+
+from pydantic import BaseModel, Field
+
+
+class CardOut(BaseModel):
+    """
+    Represents one card returned from a pack opening.
+    Node.js receives this and persists it in its own DB as part of the user's inventory.
+    """
+    content_id: uuid.UUID  # the LanguageContent row this card was built from
+    sentence_fi: str
+    sentence_en: str
+    target_fi: str
+    target_en: str
+    rarity: str
+    difficulty: float
+    power: int             # used in battle damage calculation
+
+    model_config = {"from_attributes": True}
+
+
+class PackOpenRequest(BaseModel):
+    """Sent by Node.js to open a pack after a successful challenge submission."""
+    user_id: str
+    pack_score: float = Field(ge=0.0, le=1.0)  # from the submission result
+    scenario_tags: list[str] | None = None      # optional: bias cards toward a scenario
+
+
+class PackOpenResult(BaseModel):
+    """Returned after opening a pack."""
+    pack_score: float
+    cards: list[CardOut]
+    legendary_pulled: bool  # True if any card in the pack is Legendary

--- a/card-service/app/services/rarity_engine.py
+++ b/card-service/app/services/rarity_engine.py
@@ -1,0 +1,144 @@
+"""
+Rarity engine — SKELETON.
+
+Responsible for:
+  1. Rolling the rarity of each card in a pack based on pack_score
+  2. Fetching a matching LanguageContent row for each rolled rarity
+
+Rarity probability table (base weights, pack_score = 0.0):
+  Common      50
+  Uncommon    30
+  Rare        14
+  Epic         5
+  Legendary    1
+
+A higher pack_score shifts weight toward rarer tiers.
+At pack_score = 1.0, Legendary weight becomes 10x the base.
+
+TODO: implement open_pack() and all private helpers below.
+The logic already exists in the original rarity_engine.py — port it here.
+"""
+
+import uuid
+from dataclasses import dataclass, field
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.language_content import Rarity
+
+# Difficulty bands that define each rarity tier
+RARITY_BANDS: dict[str, tuple[float, float]] = {
+    Rarity.COMMON:    (0.00, 0.20),
+    Rarity.UNCOMMON:  (0.21, 0.40),
+    Rarity.RARE:      (0.41, 0.60),
+    Rarity.EPIC:      (0.61, 0.80),
+    Rarity.LEGENDARY: (0.81, 1.00),
+}
+
+# Battle power per rarity tier
+RARITY_POWER: dict[str, int] = {
+    Rarity.COMMON:    5,
+    Rarity.UNCOMMON:  10,
+    Rarity.RARE:      20,
+    Rarity.EPIC:      35,
+    Rarity.LEGENDARY: 50,
+}
+
+# Base weights before pack_score adjustment
+BASE_WEIGHTS: dict[str, float] = {
+    Rarity.COMMON:    50.0,
+    Rarity.UNCOMMON:  30.0,
+    Rarity.RARE:      14.0,
+    Rarity.EPIC:       5.0,
+    Rarity.LEGENDARY:  1.0,
+}
+
+
+@dataclass
+class PackCard:
+    """One card result from a pack opening."""
+    content_id: uuid.UUID
+    sentence_fi: str
+    sentence_en: str
+    target_fi: str
+    target_en: str
+    rarity: str
+    difficulty: float
+    power: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.power = RARITY_POWER.get(self.rarity, 5)
+
+
+async def open_pack(
+    db: AsyncSession,
+    pack_score: float,
+    scenario_tags: list[str] | None = None,
+) -> list[PackCard]:
+    """
+    Open one pack and return a list of PackCard objects.
+
+    pack_score 0.0–1.0 controls rarity distribution.
+    Pack size comes from settings (default 5).
+
+    TODO:
+      1. Call _compute_weights(pack_score) to get adjusted rarity weights
+      2. Call _roll_rarities(weights, settings.CHALLENGE_PACK_SIZE) to roll n rarities
+      3. For each rarity, call _fetch_content_for_rarity(db, rarity, scenario_tags)
+      4. Fallback to _fetch_any_content(db) if no content matches the rarity band
+      5. Build PackCard from each row and append to cards list
+      6. Return the list
+    """
+    raise NotImplementedError
+
+
+# ── Private helpers ────────────────────────────────────────────────────────────
+
+def _compute_weights(pack_score: float) -> dict[str, float]:
+    """
+    Shift rarity weights based on pack_score.
+
+    At pack_score = 0.0: use BASE_WEIGHTS as-is.
+    At pack_score = 1.0:
+      - Common weight is halved
+      - Legendary weight is 10x base
+    Everything in between scales linearly.
+
+    TODO: port from original rarity_engine._compute_weights
+    """
+    raise NotImplementedError
+
+
+def _roll_rarities(weights: dict[str, float], n: int) -> list[str]:
+    """
+    Roll n rarities using the given weights via random.choices.
+
+    TODO: port from original rarity_engine._roll_rarities
+    """
+    raise NotImplementedError
+
+
+async def _fetch_content_for_rarity(
+    db: AsyncSession,
+    rarity: str,
+    scenario_tags: list[str] | None,
+):
+    """
+    Fetch a random active LanguageContent row matching the given rarity band.
+    Optionally filter by scenario_tags[0] if provided.
+
+    Returns None if no matching row is found.
+
+    TODO: port from original rarity_engine._fetch_content_for_rarity
+    """
+    raise NotImplementedError
+
+
+async def _fetch_any_content(db: AsyncSession):
+    """
+    Last resort fallback — grab any active LanguageContent row.
+    Used when no content matches the rolled rarity band.
+
+    TODO: port from original rarity_engine._fetch_any_content
+    """
+    raise NotImplementedError


### PR DESCRIPTION
This is PR 4 of 5 for the Python microservice split.
Builds on top of PR 3 (microservice/challenges).

Adds pack opening to card-service. When a player completes a quest,
Node.js calls this service to roll a pack of 5 cards.
The rarity of each card is weighted by the pack_score from the quest result.

## How pack opening works

1. Node.js calls POST /cards/open-pack with pack_score (0.0–1.0)
2. card-service rolls 5 rarities using weighted random based on pack_score
3. For each rolled rarity, fetches a random sentence from that difficulty band
4. Returns 5 cards with full sentence data and power values
5. Node.js receives the cards and saves them to the user's inventory
6. card-service does NOT persist inventory — that is Node's responsibility

## Rarity system

| Rarity    | Difficulty band | Base weight | Battle power |
|-----------|----------------|-------------|--------------|
| Common    | 0.00–0.20      | 50          | 5            |
| Uncommon  | 0.21–0.40      | 30          | 10           |
| Rare      | 0.41–0.60      | 14          | 20           |
| Epic      | 0.61–0.80      | 5           | 35           |
| Legendary | 0.81–1.00      | 1           | 50           |

Higher pack_score shifts weight toward rarer cards.

## New files

- `app/schemas/card.py` — CardOut, PackOpenRequest, PackOpenResult
- `app/routers/cards.py` — router skeleton with TODO comments
- `app/services/rarity_engine.py` — rarity logic skeleton with TODO comments

## TODO (for the assigned developer)

If you have no idea where to start from:

Implement all functions marked with `raise NotImplementedError` in:
- `app/services/rarity_engine.py`
- `app/routers/cards.py`

The logic is identical to the original `rarity_engine.py` in the old monolith.

## Checklist
- [x] Feature is fully done and works
- [x] Difficult parts of code have relevant comments
- [x] Feature is tested
- [x] PR includes clear description for later documentation