### PR TITLE
microservice quests implemented

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD:-lingo}
       POSTGRES_DB: lingo_db
     ports:
-      - "5433:5432"
+      - "5432:5432"
     volumes:
       - db-data:/var/lib/postgresql/data
     healthcheck:
@@ -70,7 +70,7 @@ services:
     # Mount source for local dev — remove in production
     volumes:
       - ./quest-service:/app
-    restart: unless-stopped
+    restart: on-failure:3
 
   # ── Card Service (8002) ──────────────────────────────────────────────────────
   card-service:
@@ -89,7 +89,7 @@ services:
       - lingo-net
     volumes:
       - ./card-service:/app
-    restart: unless-stopped
+    restart: on-failure:3
 
   # ── Challenge Service (8003) ─────────────────────────────────────────────────
   challenge-service:
@@ -115,7 +115,7 @@ services:
     # For Ollama access from inside Docker on macOS/Windows:
     # extra_hosts:
     #   - "host.docker.internal:host-gateway"
-    restart: unless-stopped
+    restart: on-failure:3
 
 volumes:
   db-data:

--- a/quest-service/app/services/quest_service.py
+++ b/quest-service/app/services/quest_service.py
@@ -47,7 +47,34 @@ async def generate_quest(
 
     Hint: all options must be lowercase (use .lower() when building options).
     """
-    raise NotImplementedError
+    content = None
+    print(f"llm_use={use_llm} scenario_tag={scenario_tag} difficulty_target={difficulty_target}")
+    # 1. Try DB content if not forcing LLM
+    if use_llm is False:
+        content = await _pick_content(
+            db=db,
+            user_id=user_id,
+            scenario_tag=scenario_tag,
+            difficulty_target=difficulty_target,
+        )
+
+    # 2. If content found → build from wordbank
+    if content is not None:
+        quest = await _build_from_wordbank(db, content)
+
+    # 3. Otherwise → fallback to LLM
+    else:
+        quest = await _build_from_llm(
+            db=db,
+            scenario=scenario_tag or "general",
+            difficulty=difficulty_target or 0.5,
+        )
+
+    # 4. Ensure all options are lowercase
+    if hasattr(quest, "options") and quest.options:
+        quest.options = [opt.lower() for opt in quest.options]
+
+    return quest
 
 
 async def score_answer(
@@ -66,13 +93,33 @@ async def score_answer(
       4. Create and add a QuestSubmission row
       5. Return (quest, submission)
     """
-    raise NotImplementedError
+    result = await db.execute(select(Quest).where(Quest.id == quest_id))
+    quest = result.scalars().first()
+    if quest is None:
+        raise ValueError(f"Quest not found: {quest_id}")
+
+    is_correct = quest.correct_answer.lower() == given_answer.lower()
+    xp_earned = _compute_xp(is_correct)
+    pack_score = _compute_pack_score(is_correct)
+
+    submission = QuestSubmission(
+        quest_id=quest.id,
+        user_id=user_id,
+        given_answer=given_answer,
+        is_correct=is_correct,
+        xp_earned=xp_earned,
+        pack_score=pack_score,
+    )
+    db.add(submission)
+    await db.flush()
+    return quest, submission
 
 
 # ── Private helpers — implement these ─────────────────────────────────────────
 
 async def _pick_content(
     db: AsyncSession,
+    user_id: str,
     scenario_tag: str | None,
     difficulty_target: float | None,
 ) -> LanguageContent | None:
@@ -85,7 +132,38 @@ async def _pick_content(
       - If scenario_tag: filter by scenario_tags.contains(tag)
       - Otherwise: random active row
     """
-    raise NotImplementedError
+    query = select(LanguageContent).where(LanguageContent.is_active == True)
+
+    # Filter by scenario_tag if provided
+    if scenario_tag:
+        query = query.where(LanguageContent.scenario_tags.contains(scenario_tag))
+
+    # If difficulty_target provided, get 5 nearest by difficulty
+    if difficulty_target is not None:
+        # Get rows with difficulty closest to target (within ±0.2 range)
+        min_diff = max(0.0, difficulty_target - 0.2)
+        max_diff = min(1.0, difficulty_target + 0.2)
+
+        query = query.where(
+            LanguageContent.difficulty >= min_diff,
+            LanguageContent.difficulty <= max_diff
+        ).order_by(func.abs(LanguageContent.difficulty - difficulty_target)).limit(5)
+    else:
+        # No difficulty filter, just get all matching rows
+        pass
+
+    result = await db.execute(query)
+    candidates = result.scalars().all()
+
+    # print(f"_pick_content found {len(candidates)} candidates for user_id={user_id}, "
+    #       f"scenario_tag={scenario_tag}, difficulty_target={difficulty_target}")
+
+    if not candidates:
+        return None
+
+    # Pick randomly from candidates
+    # print(f"_pick_content candidates: {random.choice(candidates)}")
+    return random.choice(candidates)
 
 
 async def _build_from_wordbank(db: AsyncSession, content: LanguageContent) -> Quest:
@@ -98,7 +176,22 @@ async def _build_from_wordbank(db: AsyncSession, content: LanguageContent) -> Qu
       3. Call _build_options() to get 4 lowercase shuffled options
       4. Persist and return Quest with source="wordbank"
     """
-    raise NotImplementedError
+    question_fi = content.sentence_fi.replace(content.target_fi, "....")
+    question_en = content.sentence_en.replace(content.target_en, "....")
+    options = await _build_options(db, content)
+
+    quest = Quest(
+        content_id=content.id,
+        source="wordbank",
+        question_fi=question_fi,
+        question_en=question_en,
+        options=options,
+        correct_answer=content.target_fi,
+        difficulty=content.difficulty,
+    )
+    db.add(quest)
+    await db.flush()
+    return quest
 
 
 async def _build_from_llm(
@@ -117,7 +210,86 @@ async def _build_from_llm(
       5. Persist and return Quest with source="llm"
       6. Retry up to 3 times on failure
     """
-    raise NotImplementedError
+    from app.services import llm_client
+
+    # Pick a random word from language_content to seed the prompt
+    result = await db.execute(
+        select(LanguageContent.target_fi)
+        .where(LanguageContent.is_active == True)
+        .order_by(func.random())
+        .limit(1)
+    )
+    seed_word = result.scalar_one_or_none()
+    if not seed_word:
+        raise RuntimeError("No language content available for LLM seeding")
+
+    # Create prompt for LLM
+    system = f"""You are a Finnish language learning assistant. Generate a fill-in-the-blank question about Finnish vocabulary.
+
+The question should be appropriate for difficulty level {difficulty:.1f} (0.0=easy, 1.0=hard).
+Context: {scenario}
+
+Return ONLY valid JSON with this exact format:
+{{
+  "sentence_fi": "Finnish sentence with [TARGET] word to blank out",
+  "sentence_en": "English translation of the sentence",
+  "target_fi": "the Finnish word that gets blanked out",
+  "target_en": "English translation of the target word",
+  "distractors": ["wrong_option1", "wrong_option2", "wrong_option3"]
+}}
+
+Requirements:
+- target_fi must appear exactly once in sentence_fi
+- All distractors must be different Finnish words
+- All options should be lowercase
+- Make it educational and natural"""
+
+    prompt = f"Generate a Finnish fill-in-the-blank question. Use '{seed_word}' as inspiration for the difficulty level. Make sure the target word fits naturally in a sentence."
+
+    # Retry up to 3 times on failure
+    for attempt in range(3):
+        try:
+            llm_response = await llm_client.generate_quest_json(prompt, system)
+
+            # Validate the response
+            required_keys = ["sentence_fi", "sentence_en", "target_fi", "target_en", "distractors"]
+            if not all(key in llm_response for key in required_keys):
+                raise ValueError(f"LLM response missing required keys: {list(llm_response.keys())}")
+
+            sentence_fi = llm_response["sentence_fi"]
+            sentence_en = llm_response["sentence_en"]
+            target_fi = llm_response["target_fi"]
+            target_en = llm_response["target_en"]
+            distractors = llm_response["distractors"]
+
+            # Validate target_fi appears in sentence_fi
+            if target_fi not in sentence_fi:
+                raise ValueError(f"target_fi '{target_fi}' not found in sentence_fi '{sentence_fi}'")
+
+            # Build the quest
+            question_fi = sentence_fi.replace(target_fi, "....")
+            question_en = sentence_en.replace(target_en, "....")
+
+            # Combine correct answer with distractors and lowercase everything
+            options = [target_fi.lower()] + [d.lower() for d in distractors]
+            random.shuffle(options)
+
+            quest = Quest(
+                source="llm",
+                question_fi=question_fi,
+                question_en=question_en,
+                options=options,
+                correct_answer=target_fi,
+                difficulty=difficulty,
+            )
+            db.add(quest)
+            await db.flush()
+            return quest
+
+        except Exception as e:
+            if attempt == 2:  # Last attempt
+                raise RuntimeError(f"LLM quest generation failed after 3 attempts: {e}") from e
+            # Continue to next attempt
 
 
 async def _build_options(db: AsyncSession, content: LanguageContent) -> list[str]:
@@ -131,12 +303,55 @@ async def _build_options(db: AsyncSession, content: LanguageContent) -> list[str
       - Combine with content.target_fi.lower()
       - Shuffle and return
     """
-    raise NotImplementedError
+    query = (
+        select(LanguageContent.target_fi)
+        .where(
+            LanguageContent.is_active == True,
+            LanguageContent.id != content.id,
+        )
+        .order_by(func.random())
+        .limit(6)
+    )
+    result = await db.execute(query)
+    distractors = [
+        target.lower()
+        for target in result.scalars().all()
+        if target and target.lower() != content.target_fi.lower()
+    ]
+
+    unique_distractors: list[str] = []
+    for item in distractors:
+        if item not in unique_distractors:
+            unique_distractors.append(item)
+        if len(unique_distractors) >= 3:
+            break
+
+    fallback = [
+        "kahvia",
+        "vettä",
+        "teetä",
+        "maitoa",
+        "leipää",
+        "omenaa",
+        "kirjaa",
+        "aamua",
+        "kahvi",
+        "uima",
+    ]
+    for pad in fallback:
+        if len(unique_distractors) >= 3:
+            break
+        if pad not in unique_distractors and pad != content.target_fi.lower():
+            unique_distractors.append(pad)
+
+    options = [content.target_fi.lower(), *unique_distractors[:3]]
+    random.shuffle(options)
+    return options
 
 
 def _compute_xp(is_correct: bool) -> int:
     """Return 10 XP for correct, 2 XP for trying."""
-    raise NotImplementedError
+    return 10 if is_correct else 2
 
 
 def _compute_pack_score(is_correct: bool) -> float:
@@ -144,4 +359,6 @@ def _compute_pack_score(is_correct: bool) -> float:
     Correct: random float in [0.50, 1.00]
     Wrong:   random float in [0.00, 0.40]
     """
-    raise NotImplementedError
+    if is_correct:
+        return random.uniform(0.50, 1.00)
+    return random.uniform(0.00, 0.40)


### PR DESCRIPTION
## Description

Microservice quests has been implemented and supports all of these APIs:
### quests/generate
```bash
curl -X POST http://localhost:8001/quests/generate \
  -H "Content-Type: application/json" \
  -d '{"user_id": "test"}'
```

### quests/generate-internal
```bash
curl -X POST http://localhost:8001/quests/generate \
  -H "Content-Type: application/json" \
  -d '{"user_id": "test"}'
```

### quests/submit
```bash
curl -X POST http://localhost:8001/quests/submit \
  -H "Content-Type: application/json" \
  -d '{
    "quest_id": "<id from generate>",
    "user_id": "test",
    "given_answer": "<one of the options>"
  }'
```

The only remaining part is how to set `use_llm` parameter in the `quests/generate` request. So, it currently works based on wordbank.
Below format does not work:
```bash
{
    "user_id": "test",
    "use_llm": true
}
```