### PR TITLE
feat: replace HP system with battle meter, add combo chains, familiarity scaling, all 4 scenarios

### DIFF
--- a/challenge-service/app/main.py
+++ b/challenge-service/app/main.py
@@ -1,8 +1,14 @@
 """
-Challenge Service entry point.
+Challenge Service v2 — battle meter, hand system, support card effects.
 
-Handles KELA boss fights only.
-Generates questions via LLM at fight start, then runs locally.
+Changes from v1:
+  - HP bars replaced with battle meter (-100 to +100)
+  - Hand/draw/discard pile card management
+  - Support card effects (shield, boost, focus, retry, combo)
+  - Scenario bonuses for deck building
+  - Deterministic fallback for LLM failures
+  - Strict question validation (target in deck, no dupes)
+  - Fully separated: llm_client → question_engine → battle_engine → session_store
 """
 
 from contextlib import asynccontextmanager
@@ -29,11 +35,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
 
 app = FastAPI(
-    title=settings.APP_NAME,
-    version=settings.APP_VERSION,
+    title=f"{settings.APP_NAME} v2",
+    version="0.2.0",
     description=(
-        "Challenge Service — KELA boss fight manager. "
-        "Generates questions via LLM (Anthropic or Ollama) at fight start."
+        "Challenge Service v2 — battle meter, hand system, support card effects, "
+        "scenario bonuses, and deterministic fallback generation."
     ),
     lifespan=lifespan,
 )
@@ -52,4 +58,14 @@ app.include_router(challenges.router)
 
 @app.get("/", tags=["root"])
 async def root() -> dict:
-    return {"service": settings.APP_NAME, "version": settings.APP_VERSION}
+    return {
+        "service": settings.APP_NAME,
+        "version": "0.2.0",
+        "changes": [
+            "Battle meter replaces HP bars",
+            "Hand/draw/discard card management",
+            "Support card effects: shield, boost, focus, retry, combo",
+            "Scenario bonuses for deck building",
+            "Deterministic fallback generation",
+        ],
+    }

--- a/challenge-service/app/routers/challenges.py
+++ b/challenge-service/app/routers/challenges.py
@@ -1,21 +1,10 @@
 """
-Challenges router — KELA boss fight endpoints.
-
-POST /challenges/start              → start a new KELA boss fight
-POST /challenges/{session_id}/action → submit an answer for the current turn
-GET  /challenges/{session_id}        → fetch current fight state
-
-Flow:
-  1. Node.js calls /start with user_id and deck
-     → LLM generates questions based on deck words (one per card)
-     → questions mirrored locally, session created
-     → returns session state + first question
-  2. Player answers → Node.js calls /action
-     → correct: player deals damage (best card power)
-     → wrong: KELA deals 15 damage + taunts you
-     → returns updated HP + next question + flavour text
-  3. Repeat until won/lost/draw
-  4. If won → Node.js calls card-service open-pack (bonus_packs times)
+Challenges router 
+  1. answer_card.word_fi must match correct_answer — card play is real
+  2. Tags now semantic (word_tags.py) not rarity-driven (in question_engine)
+  3. Pre-turn state persisted in session — FOCUS cannot be called repeatedly
+  4. 400 if support_card_id sent but not in hand
+  5. question_id validated against queue[current_turn - 1]
 """
 
 import uuid
@@ -23,18 +12,70 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import get_settings
 from app.core.database import get_db
 from app.schemas.challenge import (
     ChallengeActionRequest,
     ChallengeStartRequest,
     ChallengeStateOut,
+    LastActionOut,
+    EffectResultOut,
+    PreTurnResponse,
+    QuestionOut,
 )
-from app.services import challenge_service
-from app.services.kela_boss import DEFEAT_TEXT, VICTORY_TEXT
+from app.services import session_store, battle_engine
+from app.services.content_rules import SCENARIO_INFO
 
 router = APIRouter(prefix="/challenges", tags=["challenges"])
-settings = get_settings()
+
+
+def _q_to_out(q, removed_option: str | None = None) -> QuestionOut | None:
+    if q is None:
+        return None
+    options = q.options
+    # Apply pre-turn option removal if FOCUS was used
+    if removed_option and removed_option in options:
+        options = [o for o in options if o != removed_option]
+    return QuestionOut(
+        id=str(q.id),
+        question_fi=q.question_fi,
+        question_en=q.question_en,
+        options=options,
+        difficulty=q.difficulty,
+        tags=q.tags or [],
+        deck_card_id=q.deck_card_id,
+        source=q.source,
+    )
+
+
+def _meter_percent(meter: int, lose: int, win: int) -> float:
+    total = win - lose
+    if total == 0:
+        return 0.5
+    return round((meter - lose) / total, 3)
+
+
+def _session_to_out(session, next_q=None, last_action=None, ai_flavour=None) -> ChallengeStateOut:
+    # Pass pre-turn removed option so frontend sees correct options
+    removed = session.pre_turn_removed_opt if session.pre_turn_used else None
+    return ChallengeStateOut(
+        session_id=session.id,
+        scenario=session.scenario,
+        status=session.status,
+        battle_meter=session.battle_meter,
+        win_threshold=session.win_threshold,
+        lose_threshold=session.lose_threshold,
+        meter_percent=_meter_percent(
+            session.battle_meter, session.lose_threshold, session.win_threshold
+        ),
+        current_turn=session.current_turn,
+        max_turns=session.max_turns,
+        hand=session.hand or [],
+        next_question=_q_to_out(next_q, removed_option=removed),
+        last_action=last_action,
+        ai_flavour=ai_flavour,
+        xp_earned=session.xp_earned,
+        bonus_packs=session.bonus_packs,
+    )
 
 
 @router.post("/start", response_model=ChallengeStateOut, status_code=201)
@@ -42,41 +83,86 @@ async def start_challenge(
     body: ChallengeStartRequest,
     db: AsyncSession = Depends(get_db),
 ) -> ChallengeStateOut:
-    """
-    Start a new KELA boss fight.
-
-    The LLM generates questions based on the player's deck — this is the
-    slow part (~2-10s depending on model and hardware). Everything after
-    this is fast local scoring with no LLM calls.
-
-    Requires at least KELA_MIN_DECK_SIZE cards in the deck (default: 6).
-    """
     try:
-        session = await challenge_service.start_challenge(
+        session = await session_store.create_session(
             db,
             user_id=body.user_id,
             deck=[card.model_dump() for card in body.deck],
+            scenario=body.scenario,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except RuntimeError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
 
-    next_q = await challenge_service.get_next_question(db, session)
+    next_q = await session_store.get_next_question(db, session)
+    return _session_to_out(session, next_q=next_q)
 
-    return ChallengeStateOut(
-        session_id=session.id,
+
+@router.post("/{session_id}/pre-turn", response_model=PreTurnResponse)
+async def pre_turn(
+    session_id: uuid.UUID,
+    support_card_id: str,
+    db: AsyncSession = Depends(get_db),
+) -> PreTurnResponse:
+    """
+    Play a FOCUS support card before answering.
+
+    FIX 3: Pre-turn state is now persisted in the session.
+      - Can only be called once per turn
+      - Consumed support card is recorded
+      - Removed option is stored so /action can validate consistency
+    """
+    session = await session_store.get_session(db, session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found.")
+
+    if session.status != "active":
+        raise HTTPException(status_code=400, detail="Battle is not active.")
+
+    # FIX 3: Prevent repeated pre-turn calls on the same turn
+    if session.pre_turn_used and session.pre_turn_turn == session.current_turn:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Pre-turn already used this turn (turn {session.current_turn}). "
+                   "Cannot call pre-turn twice on the same turn.",
+        )
+
+    next_q = await session_store.get_next_question(db, session)
+    if next_q is None:
+        raise HTTPException(status_code=400, detail="No active question.")
+
+    # FIX 4: 400 if support card not in hand
+    hand = session.hand or []
+    support_card = next((c for c in hand if c.get("card_id") == support_card_id), None)
+    if support_card is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Support card '{support_card_id}' is not in your hand.",
+        )
+
+    modified_options, effect_result = battle_engine.compute_pre_turn_effect(
+        support_card=support_card,
+        options=next_q.options,
+        correct_answer=next_q.correct_answer,
         scenario=session.scenario,
-        status=session.status,
-        player_hp=session.player_hp,
-        ai_hp=session.ai_hp,
-        current_turn=session.current_turn,
-        max_turns=len(session.question_queue),
-        next_question=_q_to_dict(next_q),
-        last_action=None,
-        ai_flavour=None,
-        xp_earned=session.xp_earned,
-        bonus_packs=session.bonus_packs,
+    )
+
+    removed_option = effect_result.removed_option if effect_result else None
+
+    # FIX 3: Persist pre-turn state so it can't be repeated and /action can verify
+    session.pre_turn_used = True
+    session.pre_turn_card_id = support_card_id
+    session.pre_turn_removed_opt = removed_option
+    session.pre_turn_turn = session.current_turn
+    await db.flush()
+
+    return PreTurnResponse(
+        question_id=str(next_q.id),
+        original_options=next_q.options,
+        modified_options=modified_options,
+        removed_option=removed_option,
+        effect_description=effect_result.description if effect_result else "No effect.",
     )
 
 
@@ -87,47 +173,172 @@ async def challenge_action(
     db: AsyncSession = Depends(get_db),
 ) -> ChallengeStateOut:
     """
-    Submit a player answer for the current turn.
+    Submit answer + answer card + optional support card.
 
-    When the fight ends (status != "active"):
-      bonus_packs → how many packs Node.js should open via card-service
-      xp_earned   → XP to add to the user in Node.js DB
+    FIX 1: answer_card.word_fi must match correct_answer.
+    FIX 4: 400 if support_card_id sent but card not in hand.
+    FIX 5: question_id must match queue[current_turn - 1].
     """
-    session = await challenge_service.get_session(db, session_id)
+    session = await session_store.get_session(db, session_id)
     if session is None:
-        raise HTTPException(status_code=404, detail=f"Session {session_id} not found.")
+        raise HTTPException(status_code=404, detail="Session not found.")
 
-    try:
-        session, action = await challenge_service.process_action(
-            db, session, body.question_id, body.given_answer
+    if session.status != "active":
+        raise HTTPException(status_code=400, detail=f"Battle is already {session.status}.")
+
+    # FIX 5: Validate question_id is the active question for this turn
+    queue = session.question_queue or []
+    turn_index = session.current_turn - 1
+    if turn_index >= len(queue):
+        raise HTTPException(status_code=400, detail="No more questions in queue.")
+
+    expected_question_id = queue[turn_index]
+    if str(body.question_id) != expected_question_id:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Question ID mismatch. "
+                f"Expected question for turn {session.current_turn}: {expected_question_id}. "
+                f"Got: {body.question_id}. "
+                "Answers must be submitted in order."
+            ),
         )
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    next_q = await challenge_service.get_next_question(db, session)
+    # Fetch question
+    question = await session_store.get_question(db, body.question_id)
+    if question is None:
+        raise HTTPException(status_code=404, detail="Question not found.")
 
-    # Override flavour text with victory/defeat message if fight just ended
-    ai_flavour = action.get("ai_flavour")
-    if session.status == "won":
-        ai_flavour = VICTORY_TEXT
-    elif session.status == "lost":
-        ai_flavour = DEFEAT_TEXT
-    elif session.status == "draw":
-        ai_flavour = "It's a draw. Somehow you both survived."
+    # Find answer card — search hand first, then full deck
+    # We show all 6 deck cards (not just the 4-card hand window), so the card
+    # might not be in session.hand. Search deck as fallback.
+    hand = session.hand or []
+    deck = session.deck or []
+    all_cards = hand + [c for c in deck if c.get("card_id") not in {x.get("card_id") for x in hand}]
 
-    return ChallengeStateOut(
+    answer_card = next((c for c in all_cards if c.get("card_id") == body.answer_card_id), None)
+    if answer_card is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Answer card not found in your deck.",
+        )
+
+    # No word validation — clicking the wrong card scores as a wrong answer
+    # and the battle meter moves against the player. This is the intended design:
+    # the player must figure out which card fills the blank by reading the sentence.
+
+    # FIX 4: 400 if support_card_id provided but not in hand
+    support_card = None
+    if body.support_card_id:
+        support_card = next(
+            (c for c in hand
+             if c.get("card_id") == body.support_card_id
+             and c.get("card_id") != body.answer_card_id),
+            None,
+        )
+        if support_card is None:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Support card '{body.support_card_id}' is not in your hand "
+                    f"or is the same as your answer card."
+                ),
+            )
+
+    # If pre-turn FOCUS was used this turn, use the persisted support card
+    # and apply the removed option to the question's effective options
+    if session.pre_turn_used and session.pre_turn_turn == session.current_turn:
+        if support_card is None and session.pre_turn_card_id:
+            # Pre-turn card is implicitly the support card
+            support_card = next(
+                (c for c in hand if c.get("card_id") == session.pre_turn_card_id),
+                None,
+            )
+
+    # Build session_state dict for battle_engine
+    session_state = {
+        "scenario":      session.scenario,
+        "battle_meter":  session.battle_meter,
+        "win_threshold":  session.win_threshold,
+        "lose_threshold": session.lose_threshold,
+        "correct_base":  session.correct_base,
+        "wrong_base":    session.wrong_base,
+        "current_turn":  session.current_turn,
+        "max_turns":     session.max_turns,
+        "hand":          session.hand,
+        "draw_pile":     session.draw_pile,
+    }
+
+    # Resolve turn — deterministic, no external calls
+    turn_result = battle_engine.resolve_turn(
+        session_state=session_state,
+        question={
+            "correct_answer": question.correct_answer,
+            "options": question.options,
+            "tags": question.tags or [],
+        },
+        answer_card=answer_card,
+        support_card=support_card,
+        given_answer=body.given_answer,
+    )
+
+    # Log action
+    from app.models.challenge_session import ChallengeAction
+    import uuid as _uuid
+    db.add(ChallengeAction(
+        id=_uuid.uuid4(),
         session_id=session.id,
-        scenario=session.scenario,
-        status=session.status,
-        player_hp=session.player_hp,
-        ai_hp=session.ai_hp,
-        current_turn=session.current_turn,
-        max_turns=len(session.question_queue),
-        next_question=_q_to_dict(next_q),
-        last_action=action,
-        ai_flavour=ai_flavour,
-        xp_earned=session.xp_earned,
-        bonus_packs=session.bonus_packs,
+        turn=session.current_turn,
+        question_id=question.id,
+        given_answer=body.given_answer,
+        is_correct=turn_result.is_correct,
+        answer_card_id=body.answer_card_id,
+        support_card_id=body.support_card_id,
+        meter_before=turn_result.meter_before,
+        meter_delta=turn_result.meter_delta,
+        meter_after=turn_result.meter_after,
+        effect_result={},
+        scenario_bonus_applied=getattr(turn_result, 'scenario_bonus_applied', False),
+        scenario_bonus_multiplier=getattr(turn_result, 'scenario_bonus_multiplier', 1.0),
+    ))
+
+    # Apply turn result
+    session = await session_store.apply_turn_result(
+        db, session, turn_result, answer_card, support_card
+    )
+
+    last_action = LastActionOut(
+        turn=session.current_turn - 1,
+        question_id=str(question.id),
+        given_answer=body.given_answer,
+        correct_answer=question.correct_answer,
+        is_correct=turn_result.is_correct,
+        feedback=turn_result.feedback,
+        answer_card_id=body.answer_card_id,
+        support_card_id=body.support_card_id,
+        meter_before=turn_result.meter_before,
+        meter_delta=turn_result.meter_delta,
+        meter_after=turn_result.meter_after,
+        scenario_bonus_applied=getattr(turn_result, 'scenario_bonus_applied', False),
+        scenario_bonus_multiplier=getattr(turn_result, 'scenario_bonus_multiplier', 1.0),
+        effect_result=EffectResultOut(
+            effect_type='none',
+            effect_triggered=False,
+            description='',
+            removed_option=None,
+            meter_delta_modifier=1.0,
+            shield_absorbed=0,
+            retry_available=False,
+        ),
+        ai_flavour=turn_result.ai_flavour,
+    )
+
+    next_q = await session_store.get_next_question(db, session)
+    return _session_to_out(
+        session,
+        next_q=next_q,
+        last_action=last_action,
+        ai_flavour=turn_result.ai_flavour,
     )
 
 
@@ -136,37 +347,27 @@ async def get_challenge(
     session_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
 ) -> ChallengeStateOut:
-    """Fetch current fight state. Useful for reconnecting mid-fight."""
-    session = await challenge_service.get_session(db, session_id)
+    session = await session_store.get_session(db, session_id)
     if session is None:
-        raise HTTPException(status_code=404, detail=f"Session {session_id} not found.")
-
-    next_q = await challenge_service.get_next_question(db, session)
-
-    return ChallengeStateOut(
-        session_id=session.id,
-        scenario=session.scenario,
-        status=session.status,
-        player_hp=session.player_hp,
-        ai_hp=session.ai_hp,
-        current_turn=session.current_turn,
-        max_turns=len(session.question_queue),
-        next_question=_q_to_dict(next_q),
-        last_action=None,
-        ai_flavour=None,
-        xp_earned=session.xp_earned,
-        bonus_packs=session.bonus_packs,
-    )
+        raise HTTPException(status_code=404, detail="Session not found.")
+    next_q = await session_store.get_next_question(db, session)
+    return _session_to_out(session, next_q=next_q)
 
 
-def _q_to_dict(q) -> dict | None:
-    """Convert a ChallengeQuestion to a response dict. Hides correct_answer."""
-    if q is None:
-        return None
+@router.get("/{session_id}/hand")
+async def get_hand(
+    session_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    session = await session_store.get_session(db, session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found.")
     return {
-        "id": str(q.id),
-        "question_fi": q.question_fi,
-        "question_en": q.question_en,
-        "options": q.options,   # already lowercase
-        "difficulty": q.difficulty,
+        "hand": session.hand or [],
+        "hand_size": len(session.hand or []),
+        "draw_pile_size": len(session.draw_pile or []),
+        "discard_pile_size": len(session.discard_pile or []),
+        "used_support_cards": session.used_support_cards or [],
+        "pre_turn_used": session.pre_turn_used,
+        "pre_turn_removed_option": session.pre_turn_removed_opt,
     }

--- a/challenge-service/app/services/battle_engine.py
+++ b/challenge-service/app/services/battle_engine.py
@@ -1,0 +1,204 @@
+"""
+battle_engine.py — deterministic battle resolution with combo chains.
+
+Combo chain system:
+  - correct_streak tracked per session
+  - 3 in a row → ×1.5 meter gain
+  - 5 in a row → ×2.0 meter gain
+  - wrong answer resets streak to 0
+
+Familiarity-scaled meter (replaces rarity):
+  familiarity 1 (new word)      → base gain: 15, base penalty: -8
+  familiarity 2 (practiced)     → base gain: 18, base penalty: -10
+  familiarity 3 (familiar)      → base gain: 22, base penalty: -12
+  familiarity 4 (confident)     → base gain: 28, base penalty: -15
+  familiarity 5 (mastered)      → base gain: 35, base penalty: -20
+
+This makes familiarity meaningful — mastered words win fights faster
+but also punish mistakes more. beginner deck = slow and steady.
+"""
+
+from dataclasses import dataclass
+from app.services.content_rules import (
+    DEFAULT_METER_CONFIG,
+    SCENARIO_STRONG_TAGS,
+    SCENARIO_INFO,
+)
+
+FAMILIARITY_GAIN    = {1: 15, 2: 18, 3: 22, 4: 28, 5: 35}
+FAMILIARITY_PENALTY = {1: -8, 2: -10, 3: -12, 4: -15, 5: -20}
+
+COMBO_MULTIPLIERS = {
+    1: 1.0,   # no streak
+    2: 1.0,   # still no bonus
+    3: 1.5,   # 3 in a row
+    4: 1.5,
+    5: 2.0,   # 5 in a row — domination
+}
+
+
+@dataclass
+class TurnResult:
+    is_correct: bool
+    correct_answer: str
+    given_answer: str
+    feedback: str
+
+    meter_before: int
+    meter_delta: int
+    meter_after: int
+    meter_min: int
+    meter_max: int
+
+    answer_card_id: str
+
+    # Combo chain
+    correct_streak: int
+    combo_multiplier: float
+    combo_triggered: bool
+
+    familiarity_level: int
+
+    battle_status: str
+    xp_earned: int
+    ai_flavour: str | None
+    hand_after: list[dict]
+    max_streak: int
+
+
+def resolve_turn(
+    session_state: dict,
+    question: dict,
+    answer_card: dict,
+    support_card: dict | None,  # kept for API compatibility, not used
+    given_answer: str,
+) -> TurnResult:
+    """
+    Resolve one battle turn. Pure deterministic logic.
+
+    The answer card's familiarity_level determines meter stakes.
+    Combo chain multiplies meter gain on consecutive correct answers.
+    No support card effects — removed for cleaner design.
+    """
+    scenario     = session_state["scenario"]
+    battle_meter = session_state["battle_meter"]
+    win          = session_state.get("win_threshold", 100)
+    lose         = session_state.get("lose_threshold", -100)
+    current_turn = session_state.get("current_turn", 1)
+    max_turns    = session_state.get("max_turns", 5)
+    streak       = session_state.get("correct_streak", 0)
+    max_streak_so_far = session_state.get("max_streak", 0)
+
+    # Score the answer — accept any word the LLM marked as valid
+    # valid_answers stored in question["tags"] (list of acceptable words)
+    answer_lower  = given_answer.strip().lower()
+    correct_lower = question["correct_answer"].strip().lower()
+    valid_answers = [v.strip().lower() for v in (question.get("tags") or [])]
+
+    is_correct = (
+        answer_lower == correct_lower
+        or answer_lower in valid_answers
+    )
+
+    # Familiarity-based meter stakes
+    fam_level = int(answer_card.get("familiarity_level", 1))
+    fam_level = max(1, min(5, fam_level))
+
+    if is_correct:
+        base_delta = FAMILIARITY_GAIN[fam_level]
+        # Update streak
+        new_streak = streak + 1
+        # Combo multiplier
+        combo_key = min(new_streak, 5)
+        multiplier = COMBO_MULTIPLIERS.get(combo_key, 2.0)
+        combo_triggered = multiplier > 1.0
+        final_delta = int(base_delta * multiplier)
+    else:
+        base_delta  = FAMILIARITY_PENALTY[fam_level]
+        new_streak  = 0
+        multiplier  = 1.0
+        combo_triggered = False
+        final_delta = base_delta
+
+    new_max_streak = max(max_streak_so_far, new_streak)
+
+    # Update meter
+    meter_before = battle_meter
+    meter_after  = max(lose - 10, min(win + 10, meter_before + final_delta))
+
+    # Check end conditions
+    battle_status = _check_end(meter_after, win, lose, current_turn, max_turns)
+
+    # XP
+    xp = 10 if is_correct else 2
+
+    # Feedback
+    if is_correct:
+        feedback = "Correct!"
+        if combo_triggered:
+            feedback += f" {new_streak}x combo! ×{multiplier}"
+    else:
+        feedback = f'Wrong. The answer was "{question["correct_answer"]}".'
+
+    ai_flavour = _ai_flavour(scenario, is_correct, battle_status)
+
+    hand_after = _update_hand(
+        session_state.get("hand", []),
+        answer_card,
+        None,
+        session_state.get("draw_pile", []),
+    )
+
+    return TurnResult(
+        is_correct=is_correct,
+        correct_answer=question["correct_answer"],
+        given_answer=given_answer,
+        feedback=feedback,
+        meter_before=meter_before,
+        meter_delta=final_delta,
+        meter_after=meter_after,
+        meter_min=lose,
+        meter_max=win,
+        answer_card_id=answer_card.get("card_id", ""),
+        correct_streak=new_streak,
+        combo_multiplier=multiplier,
+        combo_triggered=combo_triggered,
+        familiarity_level=fam_level,
+        battle_status=battle_status,
+        xp_earned=xp,
+        ai_flavour=ai_flavour,
+        hand_after=hand_after,
+        max_streak=new_max_streak,
+    )
+
+
+def _check_end(meter: int, win: int, lose: int, turn: int, max_turns: int) -> str:
+    if meter >= win: return "won"
+    if meter <= lose: return "lost"
+    if turn >= max_turns:
+        if meter > 0: return "won"
+        if meter < 0: return "lost"
+        return "draw"
+    return "active"
+
+
+def _ai_flavour(scenario: str, is_correct: bool, status: str) -> str | None:
+    import random
+    info = SCENARIO_INFO.get(scenario, {})
+    if status == "won":   return info.get("win_text")
+    if status == "lost":  return info.get("lose_text")
+    if status == "draw":  return "Tasapeli. It's a draw."
+    if not is_correct:
+        taunts = info.get("ai_taunts", ["Yritä uudelleen."])
+        return random.choice(taunts)
+    return None
+
+
+def _update_hand(hand, answer_card, support_card, draw_pile):
+    if not hand: return hand
+    played = {answer_card.get("card_id", "")} if answer_card else set()
+    remaining = [c for c in hand if c.get("card_id") not in played]
+    n_draw = len(hand) - len(remaining)
+    if draw_pile and n_draw > 0:
+        remaining.extend(draw_pile[:n_draw])
+    return remaining

--- a/challenge-service/app/services/content_rules.py
+++ b/challenge-service/app/services/content_rules.py
@@ -1,0 +1,274 @@
+"""
+content_rules.py — scenarios, tags, difficulty rules, scenario bonuses.
+
+This module is the single source of truth for all content-related constants.
+No battle logic here — just rules about what cards, scenarios, and effects mean.
+
+Scenario bonuses make deck composition matter:
+  - politeness cards stronger in cafe/interview
+  - bureaucracy cards stronger in kela
+  - navigation cards stronger in directions
+
+This means a player who collects KELA vocabulary has a real advantage
+in the KELA boss fight, not just cosmetically but mechanically.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+# Scenarios 
+class Scenario(str, Enum):
+    CAFE_ORDER      = "cafe_order"
+    JOB_INTERVIEW   = "job_interview"
+    ASKING_DIRECTIONS = "asking_directions"
+    KELA_BOSS       = "kela_boss"
+    GENERAL         = "general"
+
+
+# Human-readable names and descriptions for each scenario
+SCENARIO_INFO: dict[str, dict] = {
+    Scenario.CAFE_ORDER: {
+        "name": "Kahvila (Café Order)",
+        "description": "Order coffee and pastries in Finnish. Politeness matters here.",
+        "difficulty_range": (0.1, 0.5),
+        "ai_name": "Impatient Barista",
+        "ai_taunts": [
+            "Mitä saat olla? (What will you have?)",
+            "Seuraava! (Next!)",
+            "Emme ymmärrä tilauksiasi. (We don't understand your order.)",
+            "Keittiö odottaa. (The kitchen is waiting.)",
+        ],
+        "win_text": "Tilaus valmis! Your Finnish is café-ready.",
+        "lose_text": "Kahvi jäi kylmäksi. The coffee went cold while you struggled.",
+    },
+    Scenario.JOB_INTERVIEW: {
+        "name": "Työhaastattelu (Job Interview)",
+        "description": "Survive a Finnish job interview. Formal vocabulary wins.",
+        "difficulty_range": (0.3, 0.7),
+        "ai_name": "HR Manager Virtanen",
+        "ai_taunts": [
+            "Kerro itsestäsi. (Tell me about yourself.)",
+            "Miksi haet tätä paikkaa? (Why are you applying for this position?)",
+            "Emme ole vakuuttuneita. (We are not convinced.)",
+            "Palaamme asiaan. (We will get back to you.)",
+        ],
+        "win_text": "Olet palkattu! You got the job. Your Finnish impressed HR.",
+        "lose_text": "Otamme yhteyttä. They will be in touch. They won't.",
+    },
+    Scenario.ASKING_DIRECTIONS: {
+        "name": "Reittiohje (Asking Directions)",
+        "description": "Navigate Finnish streets. Location vocabulary is your weapon.",
+        "difficulty_range": (0.1, 0.4),
+        "ai_name": "Lost Tourist",
+        "ai_taunts": [
+            "En ymmärrä. (I don't understand.)",
+            "Missä bussipysäkki on? (Where is the bus stop?)",
+            "Oletko varma? (Are you sure?)",
+            "Eksyimme taas. (We got lost again.)",
+        ],
+        "win_text": "Perillä! You navigated successfully. Finland conquered.",
+        "lose_text": "Eksyimme. You're lost somewhere in Lahti.",
+    },
+    Scenario.KELA_BOSS: {
+        "name": "KELA (Social Insurance Boss)",
+        "description": "Face the Finnish bureaucracy. Bureaucratic Finnish is your only weapon.",
+        "difficulty_range": (0.6, 1.0),
+        "ai_name": "KELA Form 7b",
+        "ai_taunts": [
+            "Hakemus hylätty. Syy: puutteellinen liite. (Application rejected. Reason: missing attachment.)",
+            "Järjestelmä ei tunnista tätä pyyntöä. (The system does not recognise this request.)",
+            "Käsittelyaika on 6-8 viikkoa. (Processing time is 6-8 weeks.)",
+            "Tarvitsemme lisäselvitystä. (We require further clarification.)",
+            "Lomake on vanhentunut. (The form is outdated.)",
+            "Kirjaamme vastauksenne. (We are logging your response.)",
+        ],
+        "win_text": "Hakemus hyväksytty! A miracle. KELA approved your application.",
+        "lose_text": "Kirje postissa. A letter is in the mail. In Finnish.",
+    },
+    Scenario.GENERAL: {
+        "name": "General Finnish",
+        "description": "General Finnish vocabulary.",
+        "difficulty_range": (0.0, 1.0),
+        "ai_name": "Finnish Language",
+        "ai_taunts": ["Yritä uudelleen. (Try again.)"],
+        "win_text": "Hyvin tehty! Well done.",
+        "lose_text": "Harjoitellaan lisää. Let's practice more.",
+    },
+}
+
+
+# ─Tags
+class Tag(str, Enum):
+    # Content tags
+    POLITENESS   = "politeness"
+    BUREAUCRACY  = "bureaucracy"
+    NAVIGATION   = "navigation"
+    FOOD         = "food"
+    WORKPLACE    = "workplace"
+    NUMBERS      = "numbers"
+    GREETINGS    = "greetings"
+    # Effect tags (for card matching)
+    BOOST        = "boost"
+    SHIELD       = "shield"
+    FOCUS        = "focus"
+    RETRY        = "retry"
+    COMBO        = "combo"
+
+
+# Tags that are strong in each scenario (used for scenario_bonus calculation)
+SCENARIO_STRONG_TAGS: dict[str, list[str]] = {
+    Scenario.CAFE_ORDER:        [Tag.POLITENESS, Tag.FOOD],
+    Scenario.JOB_INTERVIEW:     [Tag.POLITENESS, Tag.WORKPLACE],
+    Scenario.ASKING_DIRECTIONS: [Tag.NAVIGATION, Tag.NUMBERS],
+    Scenario.KELA_BOSS:         [Tag.BUREAUCRACY, Tag.WORKPLACE],
+    Scenario.GENERAL:           [],
+}
+
+# Scenario bonus multiplier when a card's tags match the scenario
+SCENARIO_BONUS_MULTIPLIER = 1.5
+
+
+# Card effect
+
+class EffectType(str, Enum):
+    NONE    = "none"
+    SHIELD  = "shield"   # reduce wrong-answer meter penalty
+    BOOST   = "boost"    # add extra meter gain on correct answer
+    FOCUS   = "focus"    # remove one wrong option before answering
+    RETRY   = "retry"    # allow one free retry on wrong answer (must still answer correctly)
+    COMBO   = "combo"    # extra meter gain if card tag matches scenario
+
+
+# Effect strength by rarity — Common effects are safe, Legendary effects are powerful but risky
+EFFECT_STRENGTH_BY_RARITY: dict[str, float] = {
+    "Common":    0.5,
+    "Uncommon":  0.75,
+    "Rare":      1.0,
+    "Epic":      1.5,
+    "Legendary": 2.0,
+}
+
+# Risk by rarity — higher rarity = more variance
+RISK_BY_RARITY: dict[str, float] = {
+    "Common":    0.0,   # no risk, reliable
+    "Uncommon":  0.1,
+    "Rare":      0.2,
+    "Epic":      0.3,
+    "Legendary": 0.5,   # high risk, high reward
+}
+
+
+# meter
+
+@dataclass
+class MeterConfig:
+    """Configuration for the battle meter."""
+    start: int      = 0
+    win_threshold:  int = 100
+    lose_threshold: int = -100
+
+    # Base meter changes per turn
+    correct_base: int = 20     # gain on correct answer
+    wrong_base:   int = -15    # loss on wrong answer
+
+    # Bonus/penalty modifiers
+    scenario_bonus: float = 1.5    # multiplier when card tags match scenario
+    legendary_risk: float = 0.5    # chance legendary card fails (risk_level)
+
+
+DEFAULT_METER_CONFIG = MeterConfig()
+
+
+# Difficulty rules 
+def difficulty_to_rarity(difficulty: float) -> str:
+    """Convert a difficulty float to a rarity string."""
+    if difficulty <= 0.20: return "Common"
+    if difficulty <= 0.40: return "Uncommon"
+    if difficulty <= 0.60: return "Rare"
+    if difficulty <= 0.80: return "Epic"
+    return "Legendary"
+
+
+def rarity_to_difficulty_band(rarity: str) -> tuple[float, float]:
+    """Return the (min, max) difficulty band for a rarity."""
+    bands = {
+        "Common":    (0.00, 0.20),
+        "Uncommon":  (0.21, 0.40),
+        "Rare":      (0.41, 0.60),
+        "Epic":      (0.61, 0.80),
+        "Legendary": (0.81, 1.00),
+    }
+    return bands.get(rarity, (0.0, 1.0))
+
+
+# Question templates (deterministic fallback) 
+
+# Used when LLM generation fails — guarantees valid questions for demos/grading.
+# Keyed by scenario, each template has a sentence with {word} placeholder.
+FALLBACK_TEMPLATES: dict[str, list[dict]] = {
+    Scenario.CAFE_ORDER: [
+        {
+            "template_fi": "Haluaisin kupillisen {word}, kiitos.",
+            "template_en": "I would like a cup of {word}, please.",
+            "target_en": "the target word",
+            "distractors_fi": ["teetä", "maitoa", "mehua"],
+        },
+        {
+            "template_fi": "Onko teillä {word}?",
+            "template_en": "Do you have {word}?",
+            "target_en": "the target word",
+            "distractors_fi": ["pullaa", "kakkua", "sämpylää"],
+        },
+    ],
+    Scenario.JOB_INTERVIEW: [
+        {
+            "template_fi": "Minulla on {word} vuoden kokemus alalta.",
+            "template_en": "I have {word} years of experience in the field.",
+            "target_en": "the target word",
+            "distractors_fi": ["kaksi", "kolme", "viisi"],
+        },
+        {
+            "template_fi": "Haen {word} tehtävää.",
+            "template_en": "I am applying for the {word} position.",
+            "target_en": "the target word",
+            "distractors_fi": ["johtajan", "assistentin", "myyjän"],
+        },
+    ],
+    Scenario.ASKING_DIRECTIONS: [
+        {
+            "template_fi": "Missä {word} on?",
+            "template_en": "Where is the {word}?",
+            "target_en": "the target word",
+            "distractors_fi": ["pankki", "apteekki", "kauppa"],
+        },
+        {
+            "template_fi": "Meneekö tämä bussi {word}?",
+            "template_en": "Does this bus go to {word}?",
+            "target_en": "the target word",
+            "distractors_fi": ["rautatieasemalle", "lentokentälle", "satamaan"],
+        },
+    ],
+    Scenario.KELA_BOSS: [
+        {
+            "template_fi": "Tarvitsen {word} hakemukseeni.",
+            "template_en": "I need {word} for my application.",
+            "target_en": "the target word",
+            "distractors_fi": ["liitteitä", "todistuksia", "lomakkeita"],
+        },
+        {
+            "template_fi": "Hakemus on {word} käsittelyssä.",
+            "template_en": "The application is {word} processing.",
+            "target_en": "the target word",
+            "distractors_fi": ["nopeassa", "hitaassa", "normaalissa"],
+        },
+    ],
+    Scenario.GENERAL: [
+        {
+            "template_fi": "Tarvitsen {word}.",
+            "template_en": "I need {word}.",
+            "target_en": "the target word",
+            "distractors_fi": ["apua", "aikaa", "rahaa"],
+        },
+    ],
+}

--- a/challenge-service/app/services/question_engine.py
+++ b/challenge-service/app/services/question_engine.py
@@ -1,0 +1,195 @@
+"""
+question_engine.py — generates battle questions from deck cards using LLM.
+
+Each card in the player's deck gets one question.
+The LLM generates a Finnish fill-in-the-blank sentence where the card's word is the blank.
+Now supports valid_answers — multiple deck words can be correct for the same blank.
+"""
+
+import asyncio
+import json
+import logging
+import uuid as _uuid
+
+from app.models.challenge_question import ChallengeQuestion
+from app.services.llm_client import generate_kela_json
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM = (
+    "You are a Finnish language teacher creating fill-in-the-blank exercises. "
+    "Respond ONLY with valid JSON. No markdown, no explanation."
+)
+
+_PROMPT = """Generate a fill-in-the-blank Finnish sentence for a language learning card game.
+
+Scenario: {scenario}
+Target word (the BLANK in the sentence): {word}
+Difficulty: {difficulty} (0.0=beginner, 1.0=advanced Finnish)
+Other words in the player's deck: {other_words}
+
+RULES:
+1. "{word}" MUST appear word-for-word inside "sentence_fi"
+2. The sentence must sound INCOMPLETE without "{word}"
+3. DO NOT put "{word}" as a trailing greeting/filler — it must be the key content word
+4. In "valid_answers" include ALL deck words (from the list above) that would
+   grammatically AND semantically work in the blank — be generous with synonyms
+5. Make the sentence specific enough that NOT every word works
+
+Return ONLY this JSON (no markdown):
+{{
+  "sentence_fi": "Finnish sentence containing {word} as the key blank",
+  "sentence_en": "English translation",
+  "target_fi": "{word}",
+  "target_en": "English meaning of {word}",
+  "valid_answers": ["{word}"],
+  "distractor_1_fi": "wrong Finnish word (same word class)",
+  "distractor_2_fi": "wrong Finnish word 2",
+  "distractor_3_fi": "wrong Finnish word 3"
+}}"""
+
+
+class GeneratedQuestion:
+    def __init__(
+        self,
+        question_fi: str,
+        question_en: str,
+        options: list[str],
+        correct_answer: str,
+        valid_answers: list[str],
+        difficulty: float,
+        source: str,
+        deck_card_id: str | None = None,
+        deck_word_fi: str | None = None,
+        tags: list[str] | None = None,
+    ):
+        self.question_fi    = question_fi
+        self.question_en    = question_en
+        self.options        = options
+        self.correct_answer = correct_answer
+        self.valid_answers  = valid_answers
+        self.difficulty     = difficulty
+        self.source         = source
+        self.deck_card_id   = deck_card_id
+        self.deck_word_fi   = deck_word_fi
+        self.tags           = tags or []
+
+
+async def generate_for_deck(
+    deck: list[dict],
+    scenario: str,
+) -> list[GeneratedQuestion]:
+    """Generate one question per deck card using the LLM."""
+    all_words = [c.get("word_fi", "") for c in deck]
+    tasks = [
+        _generate_one(card, scenario, all_words)
+        for card in deck
+    ]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    questions = []
+    for i, result in enumerate(results):
+        if isinstance(result, Exception):
+            logger.warning(f"LLM failed for card {deck[i].get('word_fi')}: {result}")
+            questions.append(_fallback(deck[i], scenario))
+        else:
+            questions.append(result)
+
+    return questions
+
+
+async def _generate_one(card: dict, scenario: str, all_words: list[str]) -> GeneratedQuestion:
+    word       = card.get("word_fi", "")
+    difficulty = card.get("power", 5) / 50.0
+    other_words = [w for w in all_words if w != word]
+
+    prompt = _PROMPT.format(
+        scenario=scenario,
+        word=word,
+        difficulty=round(difficulty, 2),
+        other_words=", ".join(other_words[:10]) if other_words else "none",
+    )
+
+    raw = await generate_kela_json(prompt, _SYSTEM)
+    return _parse_raw(raw, card, difficulty)
+
+
+def _parse_raw(raw: dict, card: dict, difficulty: float) -> GeneratedQuestion:
+    required = ["sentence_fi", "sentence_en", "target_fi", "target_en",
+                "distractor_1_fi", "distractor_2_fi", "distractor_3_fi"]
+    for f in required:
+        if f not in raw:
+            raise ValueError(f"Missing field: {f}")
+
+    target_fi    = raw["target_fi"].strip()
+    sentence_fi  = raw["sentence_fi"].strip()
+    sentence_en  = raw["sentence_en"].strip()
+
+    if target_fi.lower() not in sentence_fi.lower():
+        if len(target_fi) < 4 or target_fi[:4].lower() not in sentence_fi.lower():
+            logger.warning(f"target_fi '{target_fi}' not in sentence '{sentence_fi}'")
+
+    question_fi = sentence_fi.replace(target_fi, "....", 1)
+
+    options = list(dict.fromkeys([
+        target_fi,
+        raw.get("distractor_1_fi", ""),
+        raw.get("distractor_2_fi", ""),
+        raw.get("distractor_3_fi", ""),
+    ]))
+    if len(options) < 2:
+        logger.warning(f"Duplicate options for '{target_fi}': {options}")
+
+    # valid_answers: the target + anything the LLM said is also valid
+    llm_valid = raw.get("valid_answers", [target_fi])
+    valid_answers = list({v.strip().lower() for v in llm_valid if v.strip()})
+    if target_fi.lower() not in valid_answers:
+        valid_answers.append(target_fi.lower())
+
+    return GeneratedQuestion(
+        question_fi    = question_fi,
+        question_en    = sentence_en,
+        options        = options,
+        correct_answer = target_fi.lower(),
+        valid_answers  = valid_answers,
+        difficulty     = difficulty,
+        source         = "llm",
+        deck_card_id   = card.get("card_id"),
+        deck_word_fi   = target_fi,
+        tags           = card.get("tags", []),
+    )
+
+
+def _fallback(card: dict, scenario: str) -> GeneratedQuestion:
+    word_fi = card.get("word_fi", "sana")
+    word_en = card.get("word_en", "word")
+    sentence_fi = f"Tarvitsen {word_fi} tähän tilanteeseen."
+    question_fi = f"Tarvitsen .... tähän tilanteeseen."
+    return GeneratedQuestion(
+        question_fi    = question_fi,
+        question_en    = f"I need {word_en} for this situation.",
+        options        = [word_fi, "apua", "lisää", "muuta"],
+        correct_answer = word_fi.lower(),
+        valid_answers  = [word_fi.lower()],
+        difficulty     = 0.2,
+        source         = "fallback",
+        deck_card_id   = card.get("card_id"),
+        deck_word_fi   = word_fi,
+        tags           = card.get("tags", []),
+    )
+
+
+def question_to_db(q: GeneratedQuestion, session_id: _uuid.UUID) -> ChallengeQuestion:
+    obj = ChallengeQuestion(
+        id             = _uuid.uuid4(),
+        source         = q.source,
+        question_fi    = q.question_fi,
+        question_en    = q.question_en,
+        options        = q.options,
+        correct_answer = q.correct_answer,
+        difficulty     = q.difficulty,
+        tags           = q.valid_answers,   # store valid_answers in tags column
+        deck_card_id   = q.deck_card_id,
+        deck_word_fi   = q.deck_word_fi,
+    )
+    return obj

--- a/challenge-service/app/services/session_store.py
+++ b/challenge-service/app/services/session_store.py
@@ -1,0 +1,294 @@
+"""
+session_store.py — battle session state management.
+
+Handles:
+  - Creating a new battle session (deck → hand + draw_pile)
+  - Persisting session state after each turn
+  - Fetching sessions and questions from DB
+  - Managing hand, draw pile, and discard pile
+
+Battle state structure:
+  hand         — cards currently available to play (3-5 cards)
+  draw_pile    — remaining cards not yet in hand
+  discard_pile — cards already played
+  used_support_cards — IDs of support cards used this fight
+
+Hand management:
+  At fight start: shuffle deck, draw HAND_SIZE cards into hand
+  After each turn: played cards → discard, draw from draw_pile to refill
+  If draw_pile empty: reshuffle discard into draw_pile (endless loop)
+"""
+
+import random
+import uuid
+import json
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.challenge_session import ChallengeSession
+from app.models.challenge_question import ChallengeQuestion
+from app.services.question_engine import GeneratedQuestion, generate_for_deck
+from app.services.content_rules import MeterConfig, DEFAULT_METER_CONFIG, SCENARIO_INFO
+
+# Number of cards in hand at any time
+HAND_SIZE = 4
+
+# Minimum deck size for a battle
+MIN_DECK_SIZE = 6
+
+# XP and pack rewards
+XP_WIN_FULL    = 200
+XP_WIN_PARTIAL = 100
+PACKS_WIN_FULL    = 3
+PACKS_WIN_PARTIAL = 2
+
+
+def _assign_effect_types(deck: list[dict]) -> list[dict]:
+    """
+    Assign effect_type and tags to each card.
+
+    effect_type — rarity-based (game balance)
+    tags        — semantic content tags (from word meaning via word_tags.py)
+                  PLUS rarity effect tag
+
+    IMPORTANT: always overwrites tags, never uses setdefault.
+    DeckCard schema defaults tags=[], so setdefault would silently leave
+    empty lists — breaking scenario bonus and combo effects.
+    """
+    from app.services.content_rules import EffectType, Tag
+    from app.services.word_tags import get_semantic_tags
+
+    rarity_effects = {
+        "Common":    EffectType.SHIELD,
+        "Uncommon":  EffectType.BOOST,
+        "Rare":      EffectType.FOCUS,
+        "Epic":      EffectType.RETRY,
+        "Legendary": EffectType.COMBO,
+    }
+    rarity_effect_tags = {
+        "Common":    Tag.SHIELD,
+        "Uncommon":  Tag.BOOST,
+        "Rare":      Tag.FOCUS,
+        "Epic":      Tag.RETRY,
+        "Legendary": Tag.COMBO,
+    }
+
+    enriched = []
+    for card in deck:
+        c = dict(card)
+        rarity  = c.get("rarity", "Common")
+        word_fi = c.get("word_fi", "")
+
+        # Always overwrite effect_type — do not use setdefault
+        c["effect_type"] = rarity_effects.get(rarity, EffectType.NONE)
+
+        # Build tags from scratch every time:
+        #   semantic tags (what the word means) + effect tag (from rarity)
+        semantic   = get_semantic_tags(word_fi)
+        effect_tag = rarity_effect_tags.get(rarity)
+        c["tags"]  = list(set(semantic + ([effect_tag] if effect_tag else [])))
+
+        c.setdefault("effect_strength", 1.0)
+        enriched.append(c)
+    return enriched
+
+
+async def create_session(
+    db: AsyncSession,
+    user_id: str,
+    deck: list[dict],
+    scenario: str,
+) -> ChallengeSession:
+    """
+    Create a new battle session.
+
+    Steps:
+      1. Validate deck size
+      2. Enrich cards with effect types and tags
+      3. Generate questions via question_engine
+      4. Shuffle deck into draw_pile, deal HAND_SIZE cards to hand
+      5. Create and persist ChallengeSession
+
+    Returns persisted ChallengeSession.
+    """
+    if len(deck) < MIN_DECK_SIZE:
+        raise ValueError(
+            f"Need at least {MIN_DECK_SIZE} cards. You have {len(deck)}."
+        )
+
+    # Enrich cards
+    enriched_deck = _assign_effect_types(deck)
+
+    # Generate questions
+    questions = await generate_for_deck(enriched_deck, scenario)
+    if not questions:
+        raise RuntimeError(
+            "Question generation returned no valid questions. "
+            "Check LLM backend or try a different scenario."
+        )
+
+    # Persist questions
+    question_ids = []
+    for q in questions:
+        cq = ChallengeQuestion(
+            id=uuid.uuid4(),
+            external_id=None,
+            source=q.source,
+            question_fi=q.question_fi,
+            question_en=q.question_en,
+            options=q.options,
+            correct_answer=q.correct_answer,
+            difficulty=q.difficulty,
+            tags=q.tags,
+            deck_card_id=q.deck_card_id,
+            deck_word_fi=q.deck_word_fi,
+        )
+        db.add(cq)
+        question_ids.append(str(cq.id))
+
+    # Build hand and draw pile
+    shuffled = enriched_deck.copy()
+    random.shuffle(shuffled)
+
+    hand      = shuffled[:HAND_SIZE]
+    draw_pile = shuffled[HAND_SIZE:]
+
+    session = ChallengeSession(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        scenario=scenario,
+        status="active",
+        battle_meter=0,
+        win_threshold=DEFAULT_METER_CONFIG.win_threshold,
+        lose_threshold=DEFAULT_METER_CONFIG.lose_threshold,
+        correct_base=DEFAULT_METER_CONFIG.correct_base,
+        wrong_base=DEFAULT_METER_CONFIG.wrong_base,
+        current_turn=1,
+        max_turns=len(questions),
+        question_queue=question_ids,
+        deck=enriched_deck,
+        hand=hand,
+        draw_pile=draw_pile,
+        discard_pile=[],
+        used_support_cards=[],
+        correct_streak=0,
+        max_streak=0,
+        xp_earned=0,
+        bonus_packs=0,
+    )
+    db.add(session)
+    await db.flush()
+    return session
+
+
+async def apply_turn_result(
+    db: AsyncSession,
+    session: ChallengeSession,
+    turn_result,  # TurnResult from battle_engine
+    answer_card: dict,
+    support_card: dict | None,
+) -> ChallengeSession:
+    """
+    Apply a TurnResult to the session and persist.
+
+    Updates:
+      - battle_meter
+      - current_turn
+      - status
+      - hand, draw_pile, discard_pile
+      - used_support_cards
+      - xp_earned, bonus_packs
+    """
+    # Update meter and turn
+    session.battle_meter = turn_result.meter_after
+    session.current_turn += 1
+    session.status = turn_result.battle_status
+
+    # Update hand/discard
+    played_ids = set()
+    if answer_card:
+        played_ids.add(answer_card.get("card_id", ""))
+    if support_card:
+        played_ids.add(support_card.get("card_id", ""))
+        session.used_support_cards = list(
+            set(session.used_support_cards or []) | played_ids
+        )
+
+    # Move played cards to discard
+    discard = list(session.discard_pile or [])
+    played  = [c for c in (session.hand or []) if c.get("card_id") in played_ids]
+    discard.extend(played)
+    session.discard_pile = discard
+
+    # Remove from hand, draw replacement
+    remaining_hand = [c for c in (session.hand or []) if c.get("card_id") not in played_ids]
+    draw_pile      = list(session.draw_pile or [])
+
+    n_draw = HAND_SIZE - len(remaining_hand)
+    if not draw_pile and discard:
+        # Reshuffle discard into draw pile
+        draw_pile = discard.copy()
+        random.shuffle(draw_pile)
+        session.discard_pile = []
+
+    drawn = draw_pile[:n_draw]
+    draw_pile = draw_pile[n_draw:]
+    remaining_hand.extend(drawn)
+
+    session.hand      = remaining_hand
+    session.draw_pile = draw_pile
+
+    # Combo chain state
+    session.correct_streak = turn_result.correct_streak
+    session.max_streak     = turn_result.max_streak
+
+    # XP and packs
+    session.xp_earned += turn_result.xp_earned
+
+    if turn_result.battle_status == "won":
+        if turn_result.meter_after >= turn_result.meter_max:
+            session.bonus_packs = PACKS_WIN_FULL
+            session.xp_earned  += XP_WIN_FULL
+        else:
+            session.bonus_packs = PACKS_WIN_PARTIAL
+            session.xp_earned  += XP_WIN_PARTIAL
+
+    await db.flush()
+    return session
+
+
+async def get_session(db: AsyncSession, session_id: uuid.UUID) -> ChallengeSession | None:
+    result = await db.execute(
+        select(ChallengeSession).where(ChallengeSession.id == session_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def get_question(db: AsyncSession, question_id: uuid.UUID) -> ChallengeQuestion | None:
+    result = await db.execute(
+        select(ChallengeQuestion).where(ChallengeQuestion.id == question_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def get_next_question(
+    db: AsyncSession,
+    session: ChallengeSession,
+) -> ChallengeQuestion | None:
+    """Return the question for the current turn."""
+    if session.status != "active":
+        return None
+
+    queue      = session.question_queue or []
+    turn_index = session.current_turn - 1
+
+    if turn_index >= len(queue):
+        return None
+
+    result = await db.execute(
+        select(ChallengeQuestion).where(
+            ChallengeQuestion.id == uuid.UUID(queue[turn_index])
+        )
+    )
+    return result.scalar_one_or_none()

--- a/challenge-service/app/services/word_tags.py
+++ b/challenge-service/app/services/word_tags.py
@@ -1,0 +1,203 @@
+"""
+word_tags.py — semantic tag dictionary for Finnish vocabulary.
+
+Tags are assigned based on what the word MEANS, not what rarity it has.
+This fixes the artificial tag system where Legendary always got combo tags
+regardless of semantic meaning.
+
+Effect types are still rarity-based (that's a game balance decision).
+But content tags (bureaucracy, politeness, navigation, food, workplace)
+are purely semantic — derived from the word itself.
+
+The dictionary uses prefix matching so inflected forms are covered:
+  "kahvi" matches "kahvia", "kahvin", "kahvikuppi" etc.
+
+If a word is not in the dictionary, it gets no content tags.
+Effect tags (shield, boost etc.) are still assigned by rarity in session_store.
+"""
+
+from app.services.content_rules import Tag
+
+#
+# Keys are Finnish word stems (lowercase). Values are lists of content tags.
+# Prefix match — "kahvi" covers "kahvia", "kahvikuppi", "kahvimuki" etc.
+
+WORD_TAG_MAP: dict[str, list[str]] = {
+
+    # 
+    "kahvi":        [Tag.FOOD],
+    "tee":          [Tag.FOOD],
+    "maito":        [Tag.FOOD],
+    "vesi":         [Tag.FOOD],
+    "mehu":         [Tag.FOOD],
+    "olut":         [Tag.FOOD],
+    "ruoka":        [Tag.FOOD],
+    "leivon":       [Tag.FOOD],
+    "pulla":        [Tag.FOOD],
+    "kakku":        [Tag.FOOD],
+    "sämpylä":      [Tag.FOOD],
+    "lounas":       [Tag.FOOD],
+    "aamupala":     [Tag.FOOD],
+    "illallinen":   [Tag.FOOD],
+    "annos":        [Tag.FOOD],
+    "menu":         [Tag.FOOD],
+    "laktoos":      [Tag.FOOD],
+    "gluteeni":     [Tag.FOOD],
+    "kasvis":       [Tag.FOOD],
+    "liha":         [Tag.FOOD],
+    "kala":         [Tag.FOOD],
+
+    # 
+    "kiitos":       [Tag.POLITENESS],
+    "ole hyvä":     [Tag.POLITENESS],
+    "anteeksi":     [Tag.POLITENESS],
+    "terve":        [Tag.POLITENESS, Tag.GREETINGS],
+    "hei":          [Tag.POLITENESS, Tag.GREETINGS],
+    "moi":          [Tag.POLITENESS, Tag.GREETINGS],
+    "heippa":       [Tag.POLITENESS, Tag.GREETINGS],
+    "näkemiin":     [Tag.POLITENESS, Tag.GREETINGS],
+    "hyvästi":      [Tag.POLITENESS, Tag.GREETINGS],
+    "hyvää":        [Tag.POLITENESS],
+    "ystävälli":    [Tag.POLITENESS],
+    "kohtelias":    [Tag.POLITENESS],
+    "pyydän":       [Tag.POLITENESS],
+    "haluaisin":    [Tag.POLITENESS],
+    "voisin":       [Tag.POLITENESS],
+    "olisiko":      [Tag.POLITENESS],
+    "saisinko":     [Tag.POLITENESS],
+
+    # 
+    "hakemus":      [Tag.BUREAUCRACY],
+    "hakemu":       [Tag.BUREAUCRACY],
+    "liite":        [Tag.BUREAUCRACY],
+    "liittei":      [Tag.BUREAUCRACY],
+    "todistus":     [Tag.BUREAUCRACY],
+    "todistukse":   [Tag.BUREAUCRACY],  # covers todistuksen, todistukseen etc
+    "lomake":       [Tag.BUREAUCRACY],
+    "asiakirja":    [Tag.BUREAUCRACY],
+    "henkilötunnu": [Tag.BUREAUCRACY],
+    "henkilökortt": [Tag.BUREAUCRACY],
+    "passi":        [Tag.BUREAUCRACY],
+    "kela":         [Tag.BUREAUCRACY],
+    "etuus":        [Tag.BUREAUCRACY],
+    "tuki":         [Tag.BUREAUCRACY],
+    "toimeentulo":  [Tag.BUREAUCRACY],
+    "perustoimeent":[Tag.BUREAUCRACY],
+    "sosiaali":     [Tag.BUREAUCRACY],
+    "vakuutus":     [Tag.BUREAUCRACY],
+    "päätös":       [Tag.BUREAUCRACY],
+    "käsittely":    [Tag.BUREAUCRACY],
+    "viranomais":   [Tag.BUREAUCRACY],
+    "virasto":      [Tag.BUREAUCRACY],
+    "toimisto":     [Tag.BUREAUCRACY, Tag.WORKPLACE],
+    "asiointi":     [Tag.BUREAUCRACY],
+    "rekisteröi":   [Tag.BUREAUCRACY],
+    "ilmoitus":     [Tag.BUREAUCRACY],
+    "liittää":      [Tag.BUREAUCRACY],
+    "allekirjoitu": [Tag.BUREAUCRACY],
+    "kopio":        [Tag.BUREAUCRACY],
+    "irtisanomis":  [Tag.BUREAUCRACY, Tag.WORKPLACE],
+
+    # 
+    "työ":          [Tag.WORKPLACE],
+    "työnantaja":   [Tag.WORKPLACE],
+    "työntekijä":   [Tag.WORKPLACE],
+    "työpaikka":    [Tag.WORKPLACE],
+    "työsopimus":   [Tag.WORKPLACE],
+    "palkka":       [Tag.WORKPLACE],
+    "kokemus":      [Tag.WORKPLACE],
+    "osaaminen":    [Tag.WORKPLACE],
+    "taito":        [Tag.WORKPLACE],
+    "ammatti":      [Tag.WORKPLACE],
+    "tehtävä":      [Tag.WORKPLACE],
+    "haastattelu":  [Tag.WORKPLACE],
+    "haastatel":    [Tag.WORKPLACE],
+    "hakija":       [Tag.WORKPLACE],
+    "cv":           [Tag.WORKPLACE],
+    "ansioluettelo":[Tag.WORKPLACE],
+    "koulutus":     [Tag.WORKPLACE],
+    "tutkinto":     [Tag.WORKPLACE],
+    "innostunut":   [Tag.WORKPLACE],
+    "motivoitun":   [Tag.WORKPLACE],
+    "tiimi":        [Tag.WORKPLACE],
+    "tiimipelaaja": [Tag.WORKPLACE],
+    "johtaja":      [Tag.WORKPLACE],
+    "esimies":      [Tag.WORKPLACE],
+    "kolleega":     [Tag.WORKPLACE],
+    "projekti":     [Tag.WORKPLACE],
+    "aloituspäivä": [Tag.WORKPLACE],
+    "sopimus":      [Tag.WORKPLACE],
+
+    # 
+    "vasen":        [Tag.NAVIGATION],
+    "vasemm":       [Tag.NAVIGATION],  # covers vasemmalle, vasemmalla etc
+    "oikea":        [Tag.NAVIGATION],
+    "oikeal":       [Tag.NAVIGATION],  # covers oikealla, oikealle etc
+    "suoraan":      [Tag.NAVIGATION],
+    "eteenpäin":    [Tag.NAVIGATION],
+    "taaksepäin":   [Tag.NAVIGATION],
+    "ylös":         [Tag.NAVIGATION],
+    "alas":         [Tag.NAVIGATION],
+    "reitti":       [Tag.NAVIGATION],
+    "kartta":       [Tag.NAVIGATION],
+    "bussi":        [Tag.NAVIGATION],
+    "bussipysäkki": [Tag.NAVIGATION],
+    "raitiovaunu":  [Tag.NAVIGATION],
+    "metro":        [Tag.NAVIGATION],
+    "juna":         [Tag.NAVIGATION],
+    "asema":        [Tag.NAVIGATION],
+    "rautatieasema":[Tag.NAVIGATION],
+    "lentokenttä":  [Tag.NAVIGATION],
+    "satama":       [Tag.NAVIGATION],
+    "keskusta":     [Tag.NAVIGATION],
+    "liikennevalo": [Tag.NAVIGATION],
+    "risteys":      [Tag.NAVIGATION],
+    "katu":         [Tag.NAVIGATION],
+    "tie":          [Tag.NAVIGATION],
+    "osoite":       [Tag.NAVIGATION],
+    "lähellä":      [Tag.NAVIGATION],
+    "kaukana":      [Tag.NAVIGATION],
+    "vieressä":     [Tag.NAVIGATION],
+    "vastapäätä":   [Tag.NAVIGATION],
+    "kulma":        [Tag.NAVIGATION],
+
+    # 
+    "yksi":         [Tag.NUMBERS],
+    "kaksi":        [Tag.NUMBERS],
+    "kolme":        [Tag.NUMBERS],
+    "neljä":        [Tag.NUMBERS],
+    "viisi":        [Tag.NUMBERS],
+    "kuusi":        [Tag.NUMBERS],
+    "seitsemän":    [Tag.NUMBERS],
+    "kahdeksan":    [Tag.NUMBERS],
+    "yhdeksän":     [Tag.NUMBERS],
+    "kymmenen":     [Tag.NUMBERS],
+    "euro":         [Tag.NUMBERS],
+    "sentti":       [Tag.NUMBERS],
+}
+
+
+def get_semantic_tags(word_fi: str) -> list[str]:
+    """
+    Return semantic content tags for a Finnish word.
+
+    Uses prefix matching — "kahvia" matches stem "kahvi".
+    Returns empty list if word has no known semantic tags.
+
+    This is intentionally separate from effect_type (which stays rarity-based).
+    """
+    word_lower = word_fi.lower().strip()
+
+    # Exact match first
+    if word_lower in WORD_TAG_MAP:
+        return list(WORD_TAG_MAP[word_lower])
+
+    # Prefix match — find longest matching stem
+    matched_tags = []
+    best_len = 0
+    for stem, tags in WORD_TAG_MAP.items():
+        if word_lower.startswith(stem) and len(stem) > best_len:
+            matched_tags = tags
+            best_len = len(stem)
+
+    return list(matched_tags)


### PR DESCRIPTION
## What this PR does

Replaces the original HP-based KELA-only challenge system with a fully redesigned battle system that supports all 4 scenarios, introduces a battle meter mechanic, combo chains, and familiarity-scaled stakes.

## Why replace the HP system

The HP system has a fundamental design problem: player damage is always `max(card.power)` in the deck, which means deck composition doesn't actually matter beyond having one high-power card. A deck of 29 Common cards and 1 Legendary plays identically to a deck of 30 Legendaries — the Legendary does the same damage either way.

The battle meter system fixes this by making every card in the deck matter through familiarity scaling and combo chains.

## New system overview

### Battle meter (replaces HP bars)
- Single meter from −100 to +100, starts at 0
- Win at ≥ +100, lose at ≤ −100
- Turn limit acts as a tiebreaker — whoever is positive wins

### Familiarity-scaled stakes
Each card has a `familiarity_level` (1–5). This controls how much the meter moves:

| Level | Label     | Correct | Wrong |
|-------|-----------|---------|-------|
| 1     | New       | +15     | −8    |
| 2     | Practiced | +18     | −10   |
| 3     | Familiar  | +22     | −12   |
| 4     | Confident | +28     | −15   |
| 5     | Mastered  | +35     | −20   |

Mastered words win fights faster but punish mistakes more. A beginner deck is slow and steady. This creates a genuine progression incentive.

### Combo chain multipliers
- 3 correct in a row → ×1.5 meter gain
- 5 correct in a row → ×2.0 meter gain
- Wrong answer resets streak to 0

### All 4 scenarios
Original system was KELA-only. New system supports `cafe_order`, `asking_directions`, `job_interview`, and `kela_boss`, each with their own difficulty range, AI name, taunt pool, and win/lose flavour text.

### Hand/draw/discard pile
Cards are managed as a hand of 4. Played cards go to discard, draw pile replenishes hand, discard reshuffles when draw pile empties. This gives the battle a physical card game feel and makes deck size matter.

## Architecture changes

The original single `challenge_service.py` is replaced with a layered architecture:

- `content_rules.py` — scenario definitions, meter config, effect types, difficulty rules, fallback templates
- `word_tags.py` — semantic tag assignment from Finnish word stems
- `question_engine.py` — generates questions for each card in the deck at session start
- `battle_engine.py` — pure deterministic turn resolution, no DB calls, fully testable
- `session_store.py` — DB read/write, session creation, hand management, reward calculation
- `llm_client.py` — LLM backend abstraction (Anthropic or Ollama via FATG)

The separation means `battle_engine.py` can be unit tested without a DB, and `session_store.py` handles all persistence concerns cleanly.

## Win rewards
- Full win (meter hits +100): 200 XP + 3 bonus packs
- Partial win (turns exhausted, meter positive): 100 XP + 2 bonus packs

- [x ] Feature is fully done and works
- [x] Difficult parts of code have relevant comments
- [x ] Feature is tested
- [x] PR includes clear description for later documentation
