### PR TITLE
feat: propagate content_type through card-service response

### DIFF
--- a/card-service/app/schemas/card.py
+++ b/card-service/app/schemas/card.py
@@ -5,6 +5,11 @@ CardOut — one card returned from a pack opening.
   Node.js receives these and saves them to the user's inventory.
   This service generates them but does NOT persist them.
 
+  content_type drives the frontend card layout:
+    noun   → image emoji + word + sentence + translation
+    phrase → usage context + word + meaning
+    idiom  → literal meaning → actual meaning + example
+
 PackOpenRequest — sent by Node.js after a successful quest submission.
 PackOpenResult  — returned to Node.js with the rolled cards.
 """
@@ -22,6 +27,7 @@ class CardOut(BaseModel):
     rarity: str
     difficulty: float
     power: int              # damage value in boss fights
+    content_type: str       # "noun" | "phrase" | "idiom"
 
 
 class PackOpenRequest(BaseModel):


### PR DESCRIPTION
## What this PR does

Small follow-up to the foundation PR. Ensures `content_type` set on `LanguageContent` rows actually reaches Node.js and the frontend through the card-service pack opening response.

## Changes

### `rarity_engine.py`
- Added `content_type` field to `PackCard` dataclass
- Reads `content_type` from the `LanguageContent` row via `getattr` with a safe `phrase` fallback — degrades gracefully if the column hasn't migrated yet

### `card.py` (schemas)
- Added `content_type: str` to `CardOut`

### `routers/cards.py`
- Passes `content_type` through in the `CardOut` builder

## Why this is a separate PR from foundation
The foundation PR adds `content_type` to the data model. This PR adds it to the API response. Keeping them separate makes it easier to review — one PR is a DB/model concern, the other is an API contract concern. If the foundation PR needs changes, this one doesn't need to be touched.

## What content_type enables downstream
Node.js stores `content_type` in `user_cards`. The frontend uses it to render three distinct card layouts:
- `noun` — picture + word + example sentence
- `phrase` — usage sentence first, word highlighted below
- `idiom` — expression name, meaning block, English example

- [x ] Feature is fully done and works
- [x] Difficult parts of code have relevant comments
- [x ] Feature is tested
- [x] PR includes clear description for later documentation
