### PR TITLE
Portainer ready fixes. [build-all]

### DIFF
--- a/.github/workflows/build_nginx_docker.yaml
+++ b/.github/workflows/build_nginx_docker.yaml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   build-docker:
     runs-on: ubuntu-latest
-    if: contains(github.event.head_commit.message, '[build-auth]') || contains(github.event.head_commit.message, '[build-all]')
+    if: contains(github.event.head_commit.message, '[build-frontend]') || contains(github.event.head_commit.message, '[build-all]')
 
     steps:
       - name: Checkout repository

--- a/backend/src/config/config.js
+++ b/backend/src/config/config.js
@@ -6,7 +6,7 @@ dotenv.config({ override: true });
 const config = {
 	port: process.env.PORT || 3000,
 	db: {
-		host: process.env.DB_HOST || 'localhost',
+		host: process.env.DB_HOST || 'postgres',
 		port: Number(process.env.DB_PORT) || 5432,
 		user: process.env.DB_USER || 'user',
 		password: process.env.DB_PASSWORD || 'password',

--- a/challenge-service/app/core/config.py
+++ b/challenge-service/app/core/config.py
@@ -26,8 +26,8 @@ class Settings(BaseSettings):
     SERVICE_SECRET: str = "changeme"
 
     # URLs for inter-service calls
-    QUEST_SERVICE_URL:  str = "http://quest-service:8001"
-    CARD_SERVICE_URL:   str = "http://card-service:8002"
+    QUEST_SERVICE_URL:  str = "http://my-stack_quest:8001"
+    CARD_SERVICE_URL:   str = "http://my-stack_card:8002"
     QUEST_SERVICE_SECRET: str = "changeme"
 
     # LLM config (for KELA boss question generation)

--- a/frontend/nginx/default.conf
+++ b/frontend/nginx/default.conf
@@ -32,5 +32,6 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $forwarded_proto;
     proxy_set_header Authorization $http_authorization;
+    
   }
 }

--- a/game-backend/src/config/config.js
+++ b/game-backend/src/config/config.js
@@ -4,11 +4,10 @@ dotenv.config({ override: true });
 const config = {
 	port: process.env.PORT || 4000,
 	services: {
-		quest: process.env.QUEST_SERVICE_URL || "http://localhost:8001",
-        card: process.env.CARD_SERVICE_URL || "http://localhost:8002",
-        challenge: process.env.CHALLENGE_SERVICE_URL || "http://localhost:8003",
-		auth: process.env.AUTH_SERVICE_URL || "http://localhost:3000/api",
-        sharedSecret: process.env.SERVICE_SHARED_SECRET || "dev_secret",
+		quest: process.env.QUEST_SERVICE_URL || "http://my-stack_quest:8001",
+		card: process.env.CARD_SERVICE_URL || "http://my-stack_card:8002",
+		challenge: process.env.CHALLENGE_SERVICE_URL || "http://my-stack_challenge:8003",
+		auth: process.env.AUTH_SERVICE_URL || "http://my-stack_auth:3000/api",
 		}
 	
 };


### PR DESCRIPTION
Made the app portainer ready. backend/database/init.sql — this needs to be run against postgres on first deploy. Either add it to the stack as a postgres init script or document it as a manual step.