### PR TITLE
fix: add esbuild build script for auth prod Dockerfile

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "main": "app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "nodemon app.js"
+    "dev": "nodemon app.js",
+    "build": "esbuild app.js --bundle --platform=node --outfile=dist/app.js --external:bcrypt --external:pg-native"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Adds a build script to backend/package.json so prod.Dockerfile can bundle the Express app via esbuild for Node SEA. Fixes the CI/CD auth image build failure.